### PR TITLE
Improve the driver: switching to pubsub paradigm

### DIFF
--- a/wx_armor/README.md
+++ b/wx_armor/README.md
@@ -33,7 +33,7 @@
    $ websocat ws://<ip>:<port>/api/engage
    ```
    
-   You can issue command like `READ`, `SETPOS [<the joint positions>]`, `TORQUE ON` and `TORQUE OFF`.
+   You can issue command like `SUBSCRIBE`, `SETPOS [<the joint positions>]`, `TORQUE ON` and `TORQUE OFF`.
      
 ## Deployment Guide
 

--- a/wx_armor/wx_armor/wx_armor.cc
+++ b/wx_armor/wx_armor/wx_armor.cc
@@ -3,8 +3,9 @@
 #include "spdlog/spdlog.h"
 #include "wx_armor/wx_armor_ws.h"
 
+using horizon::wx_armor::Driver;
 using horizon::wx_armor::GetEnv;
-using horizon::wx_armor::StartDriverLoop;
+using horizon::wx_armor::WxArmorWebController;
 
 /* This is the entry point of the long running daemon.
  *
@@ -35,7 +36,7 @@ using horizon::wx_armor::StartDriverLoop;
  */
 
 int main(int argc, char** argv) {
-  StartDriverLoop();
+  Driver();  // Ensure driver is up and running.
   drogon::app()
       .addListener("0.0.0.0", GetEnv<int>("WX_ARMOR_WS_PORT", 8027))
       .setClientMaxWebSocketMessageSize(1 * 1024 * 1024 /* 1MB */)

--- a/wx_armor/wx_armor/wx_armor_driver.h
+++ b/wx_armor/wx_armor/wx_armor_driver.h
@@ -118,7 +118,7 @@ class WxArmorDriver {
   ~WxArmorDriver();
 
   /**
-   * @brief Fetches the latest sensor data from the robot and caches it.
+   * @brief Read the latest sensor data from the robot and returns it.
    * @details This method is blocking and typically takes around 2ms to
    * complete.
    */

--- a/wx_armor/wx_armor/wx_armor_ws.cc
+++ b/wx_armor/wx_armor/wx_armor_ws.cc
@@ -64,7 +64,7 @@ void WxArmorWebController::handleNewMessage(const WebSocketConnectionPtr &conn,
       }
       Driver()->SetPosition(position);
     } else if (Match("SUBSCRIBE")) {
-      publisher_.Register(conn);
+      publisher_.Subscribe(conn);
     } else if (Match("TORQUE ON")) {
       Driver()->TorqueOn();
     } else if (Match("TORQUE OFF")) {
@@ -75,7 +75,7 @@ void WxArmorWebController::handleNewMessage(const WebSocketConnectionPtr &conn,
 
 void WxArmorWebController::handleConnectionClosed(
     const WebSocketConnectionPtr &conn) {
-  publisher_.Unregister(conn);
+  publisher_.Unsubscribe(conn);
   spdlog::info("A connection is closed.");
 }
 
@@ -108,13 +108,13 @@ WxArmorWebController::Publisher::~Publisher() {
   }
 }
 
-void WxArmorWebController::Publisher::Register(
+void WxArmorWebController::Publisher::Subscribe(
     const WebSocketConnectionPtr &conn) {
   std::lock_guard<std::mutex> lock{conns_mutex_};
   conns_.emplace_back(conn);
 }
 
-void WxArmorWebController::Publisher::Unregister(
+void WxArmorWebController::Publisher::Unsubscribe(
     const WebSocketConnectionPtr &conn) {
   std::lock_guard<std::mutex> lock{conns_mutex_};
   conns_.erase(std::remove(conns_.begin(), conns_.end(), conn), conns_.end());

--- a/wx_armor/wx_armor/wx_armor_ws.cc
+++ b/wx_armor/wx_armor/wx_armor_ws.cc
@@ -31,11 +31,6 @@ WxArmorDriver *Driver() {
   return driver.get();
 }
 
-void StartDriverLoop() {
-  // This will start the internal reading loop thread.
-  Driver()->StartLoop();
-}
-
 void WxArmorWebController::handleNewMessage(const WebSocketConnectionPtr &conn,
                                             std::string &&message,
                                             const WebSocketMessageType &type) {
@@ -55,10 +50,7 @@ void WxArmorWebController::handleNewMessage(const WebSocketConnectionPtr &conn,
   };
 
   if (type == WebSocketMessageType::Text) {
-    if (Match("READ")) {
-      nlohmann::json reading = Driver()->SensorDataToJson();
-      conn->send(reading.dump());
-    } else if (Match("SETPOS")) {
+    if (Match("SETPOS")) {
       // Update the states for bookkeeping purpose.
       ClientState &state = conn->getContextRef<ClientState>();
       state.engaging = true;
@@ -71,6 +63,8 @@ void WxArmorWebController::handleNewMessage(const WebSocketConnectionPtr &conn,
         position[i] = json.at(i).get<float>();
       }
       Driver()->SetPosition(position);
+    } else if (Match("SUBSCRIBE")) {
+      publisher_.Register(conn);
     } else if (Match("TORQUE ON")) {
       Driver()->TorqueOn();
     } else if (Match("TORQUE OFF")) {
@@ -81,6 +75,7 @@ void WxArmorWebController::handleNewMessage(const WebSocketConnectionPtr &conn,
 
 void WxArmorWebController::handleConnectionClosed(
     const WebSocketConnectionPtr &conn) {
+  publisher_.Unregister(conn);
   spdlog::info("A connection is closed.");
 }
 
@@ -89,6 +84,40 @@ void WxArmorWebController::handleNewConnection(
   conn->setContext(std::make_shared<ClientState>());
   spdlog::info("A new connection is established.");
   conn->send("ok");
+}
+
+WxArmorWebController::Publisher::Publisher() {
+  thread_ = std::jthread([this]() {
+    while (!shutdown_.load()) {
+      SensorData sensor_data = Driver()->Read();
+      std::string message = nlohmann::json(sensor_data).dump();
+      std::unique_lock<std::mutex> lock{conns_mutex_};
+      for (const WebSocketConnectionPtr &conn : conns_) {
+        conn->send(message);
+      }
+      lock.unlock();
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+  });
+}
+
+WxArmorWebController::Publisher::~Publisher() {
+  shutdown_.store(true);
+  if (thread_.joinable()) {
+    thread_.join();
+  }
+}
+
+void WxArmorWebController::Publisher::Register(
+    const WebSocketConnectionPtr &conn) {
+  std::lock_guard<std::mutex> lock{conns_mutex_};
+  conns_.emplace_back(conn);
+}
+
+void WxArmorWebController::Publisher::Unregister(
+    const WebSocketConnectionPtr &conn) {
+  std::lock_guard<std::mutex> lock{conns_mutex_};
+  conns_.erase(std::remove(conns_.begin(), conns_.end(), conn), conns_.end());
 }
 
 }  // namespace horizon::wx_armor

--- a/wx_armor/wx_armor/wx_armor_ws.h
+++ b/wx_armor/wx_armor/wx_armor_ws.h
@@ -53,17 +53,26 @@ class WxArmorWebController
   WS_PATH_LIST_END
 
  private:
+  // The publisher is responsible for continuously (by running a background
+  // thread) read the sensor data and publish it to the clients that subscribe
+  // the sensor data.
   class Publisher {
    public:
     Publisher();
     ~Publisher();
-    void Register(const drogon::WebSocketConnectionPtr &conn);
-    void Unregister(const drogon::WebSocketConnectionPtr &conn);
+
+    // Add the client (identified by the connection) to the subscribption list.
+    void Subscribe(const drogon::WebSocketConnectionPtr &conn);
+
+    // Remove the client (identified by the connection) to the subscribption
+    // list.
+    void Unsubscribe(const drogon::WebSocketConnectionPtr &conn);
 
    private:
-    std::atomic_bool shutdown_{false};
-    std::mutex conns_mutex_;
+    std::mutex conns_mutex_;  // protects conns_
     std::vector<drogon::WebSocketConnectionPtr> conns_{};
+
+    std::atomic_bool shutdown_{false};
     std::jthread thread_{};
   };
 


### PR DESCRIPTION
## Overview

This PR updates the mechanism on how the client receives the sensor data. In detail:

1. The client can send `SUBSCRIBE` command to the websocket server
2. Upon receiving `SUBSCRIBE`, the server will start to continuously read the latest sensor data and publish them to the client via websocket, typically every 2ms ~ 3ms.

This ensures that the client is always getting sensor data as fresh as possible, without having to proactively waiting for the read.

## Changes

1. The driver does not maintain its own read loop any more. `StartReadLoop` is removed.
2. The driver does not maintain its own latest reading any more. `latest_reading_` is removed.
3. Simplify the `FetchSensorData` and rename it to `Read`.
4. On the websocket server side
    - Add a new object `Publisher`, which under the hood run a background thread that continuously read the sensor data and publish them to the subscribing clients.
    - Handles `SUBSCRIBE` command.

## Testing

Tested with the server and client on the same machine (so as to eliminate the factor of network stability), getting the freshness reading like:

```
    5.0067901611328125e-06
    4.0531158447265625e-06
    5.9604644775390625e-06
    5.0067901611328125e-06
    4.76837158203125e-06
    3.337860107421875e-06
    4.5299530029296875e-06
    5.9604644775390625e-06
    4.0531158447265625e-06
    3.5762786865234375e-06
    3.5762786865234375e-06
    4.5299530029296875e-06
    5.0067901611328125e-06
    4.76837158203125e-06
    8.58306884765625e-06
    4.5299530029296875e-06
    7.152557373046875e-06
    5.4836273193359375e-06
    5.7220458984375e-06
    4.291534423828125e-06
    3.814697265625e-06
    4.0531158447265625e-06
    3.5762786865234375e-06
    3.5762786865234375e-06
    4.5299530029296875e-06
    4.5299530029296875e-06
    3.814697265625e-06
```