### PR TITLE
[Small] More robust wx_armor: do not crash when hitting a syncRead failure

### DIFF
--- a/wx_armor/default.nix
+++ b/wx_armor/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , lib
+, makeWrapper
 , cmake
 , fetchFromGitHub
 , DynamixelSDK
@@ -16,7 +17,7 @@ stdenv.mkDerivation rec {
 
   src = ./.;
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake makeWrapper ];
 
   buildInputs = [
     DynamixelSDK
@@ -30,6 +31,8 @@ stdenv.mkDerivation rec {
   postInstall = ''
     mkdir -p $out/etc/wx_armor
     ln -s $src/configs/wx250s_motor_config.yaml $out/etc/wx_armor
+    makeWrapper $out/bin/wx_armor $out/bin/debug_wx_armor \
+        --set WX_ARMOR_MOTOR_CONFIG $out/etc/wx_armor/wx250s_motor_config.yaml
   '';
 
   meta = with lib; {
@@ -38,5 +41,4 @@ stdenv.mkDerivation rec {
     license = licenses.asl20;
     maintainers = with maintainers; [ breakds ];
   };
-
 }

--- a/wx_armor/wx_armor/wx_armor_driver.cc
+++ b/wx_armor/wx_armor/wx_armor_driver.cc
@@ -269,7 +269,7 @@ WxArmorDriver::WxArmorDriver(const std::string &usb_port,
 
 WxArmorDriver::~WxArmorDriver() {}
 
-SensorData WxArmorDriver::Read() {
+std::optional<SensorData> WxArmorDriver::Read() {
   std::vector<int32_t> buffer(profile_.joint_ids.size());
   const uint8_t num_joints = static_cast<uint8_t>(buffer.size());
 
@@ -284,8 +284,8 @@ SensorData WxArmorDriver::Read() {
 
   if (!dxl_wb_.syncRead(
           read_handler_index_, profile_.joint_ids.data(), num_joints, &log)) {
-    spdlog::critical("Failed to syncRead: {}", log);
-    std::abort();
+    spdlog::warn("Failed to syncRead: {}", log);
+    return std::nullopt;
   }
 
   // We use the time here as the timestamp for the latest reading. This is,
@@ -349,7 +349,7 @@ SensorData WxArmorDriver::Read() {
         dxl_wb_.convertValue2Current(profile_.joint_ids[i], buffer[i]);
   }
 
-  return result;
+  return std::move(result);
 }
 
 void WxArmorDriver::SetPosition(const std::vector<float> &position) {

--- a/wx_armor/wx_armor/wx_armor_driver.h
+++ b/wx_armor/wx_armor/wx_armor_driver.h
@@ -40,6 +40,7 @@
 #include <limits>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <thread>
 
 #include "dynamixel_workbench_toolbox/dynamixel_workbench.h"
@@ -121,8 +122,11 @@ class WxArmorDriver {
    * @brief Read the latest sensor data from the robot and returns it.
    * @details This method is blocking and typically takes around 2ms to
    * complete.
+   *
+   * @return The read sensor data if the read is successful. Or std::nullopt if
+   *         the read fails.
    */
-  SensorData Read();
+  std::optional<SensorData> Read();
 
   /**
    * @brief Sets the position of the robot's joints.

--- a/wx_armor/wx_armor/wx_armor_ws.h
+++ b/wx_armor/wx_armor/wx_armor_ws.h
@@ -74,6 +74,11 @@ class WxArmorWebController
 
     std::atomic_bool shutdown_{false};
     std::jthread thread_{};
+
+    // Book keeping of the number of read errors in a row. Reset to 0 as soon as
+    // a successful read is seen. Server will crash as soon as this number
+    // exceeds the threshold.
+    int num_consecutive_read_errors_ = 0;
   };
 
   Publisher publisher_;


### PR DESCRIPTION
Previously, hitting a syncRead failure will crash the program. This is undesired if we just had a single instance of syncRead in the middle. 

After this change, it will just ignore this incident and do not send data to the client for that particular read.

Also piggybacked a change that provide a binary which can find the config with a wrapper (not important, just for debugging purpose).