### PR TITLE
Support current limit for wx_armor

### DIFF
--- a/wx_armor/wx_armor/robot_profile.cc
+++ b/wx_armor/wx_armor/robot_profile.cc
@@ -80,3 +80,25 @@ bool convert<horizon::wx_armor::RobotProfile>::decode(
 }
 
 }  // namespace YAML
+
+namespace horizon::wx_armor {
+
+std::string_view OpModeName(OpMode mode) {
+  switch (mode) {
+    case OpMode::CURRENT:
+      return "CURRENT";
+    case OpMode::VELOCITY:
+      return "VELOCITY";
+    case OpMode::POSITION:
+      return "POSITION";
+    case OpMode::CURRENT_BASED_POSITION:
+      return "CURRENT_BASED_POSITION";
+    case OpMode::PWM:
+      return "PWM";
+    case OpMode::TORQUE:
+      return "TORQUE";
+  }
+  return "UNKNOWN";
+}
+
+}  // namespace horizon::wx_armor

--- a/wx_armor/wx_armor/robot_profile.h
+++ b/wx_armor/wx_armor/robot_profile.h
@@ -27,6 +27,7 @@
 #include <chrono>
 #include <cstdlib>
 #include <map>
+#include <string_view>
 #include <vector>
 
 #include "yaml-cpp/yaml.h"
@@ -37,12 +38,16 @@ namespace horizon::wx_armor {
 // determines how the underlying controller works and what kind of commands the
 // motor accepts.
 enum class OpMode : int {
-  CURRENT = 0,   // Electric current controller
-  VELOCITY = 1,  // Velocity controller
-  POSITION = 3,  // Position controller
-  PWM = 16,      // Pulse-width modulation controller
-  TORQUE = 100,  // Torque controller
+  CURRENT = 0,                 // Electric current controller
+  VELOCITY = 1,                // Velocity controller
+  POSITION = 3,                // Position controller
+  CURRENT_BASED_POSITION = 5,  // Current based position controller
+  PWM = 16,                    // Pulse-width modulation controller
+  TORQUE = 100,                // Torque controller
 };
+
+// Convert the OpMode enum to a string e.g. for debugging purpose.
+std::string_view OpModeName(OpMode mode);
 
 // Stores the metadata of a Dynamixel motor in the robot. Each motor in the
 // robot is associated with an "ID". When communicating with the motors, the

--- a/wx_armor/wx_armor/wx_armor_driver.h
+++ b/wx_armor/wx_armor/wx_armor_driver.h
@@ -111,10 +111,15 @@ class WxArmorDriver {
    * @param motor_config_path Filesystem path to the motor configuration file.
    * @param flash_eeprom Flag to indicate whether to flash the EEPROM on
    * construction.
+   * @param current_limit The maximum current (torque) that the motor can
+   * generate. It takes value between 0 and 1000. A value of 0 means no current
+   * limit, and a small non-zero current limit protects the robot from
+   * generating too much torque when there is a huge external force/torque.
    */
   WxArmorDriver(const std::string &usb_port,
                 std::filesystem::path motor_config_path,
-                bool flash_eeprom = false);
+                bool flash_eeprom = false,
+                int32_t current_limit = 250);
 
   ~WxArmorDriver();
 

--- a/wx_armor/wx_armor/wx_armor_ws.cc
+++ b/wx_armor/wx_armor/wx_armor_ws.cc
@@ -27,8 +27,9 @@ WxArmorDriver *Driver() {
                 .parent_path() /
             "configs" / "wx250s_motor_config.yaml");
     int flash_eeprom = GetEnv<int>("WX_ARMOR_FLASH_EEPROM", 0);
+    int current_limit = GetEnv<int>("WX_ARMOR_MOTOR_CURRENT_LIMIT", 250);
     return std::make_unique<WxArmorDriver>(
-        usb_port, motor_config, static_cast<bool>(flash_eeprom));
+        usb_port, motor_config, static_cast<bool>(flash_eeprom), current_limit);
   }();
   return driver.get();
 }


### PR DESCRIPTION
## Motivation

When there is a big external force, we want to limit the torque that the motor generates so that the external torque can be alleviated by rotation of gear instead of abrasion of gear.

## What has been changed?

Added one more option `WX_ARMOR_MOTOR_CURRENT_LIMIT`.

1. If it is set to 0, the behavior will be exactly the same as before. All motor works under `POSITION` mode.
2. If it is set to 1 ~ 1000, all the XM motors will work under `CURRENT_BASED_POSITION` mode, with the specified current limit.

By default, the current limit is set to 250.

## How is it tested?

Tested with physical deployment.