### PR TITLE
Add `MOVETO` which is `SETPOS` which support setting moving time

### DIFF
--- a/configs/wx250s_motor_config.yaml
+++ b/configs/wx250s_motor_config.yaml
@@ -65,7 +65,7 @@ motors:
     ID: 1
     Baud_Rate: 3
     Return_Delay_Time: 0
-    Drive_Mode: 0
+    Drive_Mode: 4
     Velocity_Limit: 131
     Min_Position_Limit: 0
     Max_Position_Limit: 4095
@@ -75,7 +75,7 @@ motors:
     ID: 2
     Baud_Rate: 3
     Return_Delay_Time: 0
-    Drive_Mode: 0
+    Drive_Mode: 4
     Velocity_Limit: 131
     Min_Position_Limit: 819
     Max_Position_Limit: 3345
@@ -85,7 +85,7 @@ motors:
     ID: 3
     Baud_Rate: 3
     Return_Delay_Time: 0
-    Drive_Mode: 1
+    Drive_Mode: 5
     Velocity_Limit: 131
     Min_Position_Limit: 819
     Max_Position_Limit: 3345
@@ -95,7 +95,7 @@ motors:
     ID: 4
     Baud_Rate: 3
     Return_Delay_Time: 0
-    Drive_Mode: 0
+    Drive_Mode: 4
     Velocity_Limit: 131
     Min_Position_Limit: 648
     Max_Position_Limit: 3094
@@ -105,7 +105,7 @@ motors:
     ID: 5
     Baud_Rate: 3
     Return_Delay_Time: 0
-    Drive_Mode: 1
+    Drive_Mode: 5
     Velocity_Limit: 131
     Min_Position_Limit: 648
     Max_Position_Limit: 3094
@@ -115,7 +115,7 @@ motors:
     ID: 6
     Baud_Rate: 3
     Return_Delay_Time: 0
-    Drive_Mode: 0
+    Drive_Mode: 4
     Velocity_Limit: 131
     Min_Position_Limit: 0
     Max_Position_Limit: 4095
@@ -125,7 +125,7 @@ motors:
     ID: 7
     Baud_Rate: 3
     Return_Delay_Time: 0
-    Drive_Mode: 1
+    Drive_Mode: 5
     Velocity_Limit: 131
     Min_Position_Limit: 910
     Max_Position_Limit: 3447
@@ -135,7 +135,7 @@ motors:
     ID: 8
     Baud_Rate: 3
     Return_Delay_Time: 0
-    Drive_Mode: 0
+    Drive_Mode: 4
     Velocity_Limit: 131
     Min_Position_Limit: 0
     Max_Position_Limit: 4095
@@ -145,7 +145,7 @@ motors:
     ID: 9
     Baud_Rate: 3
     Return_Delay_Time: 0
-    Drive_Mode: 0
+    Drive_Mode: 4
     Velocity_Limit: 131
     Min_Position_Limit: 0
     Max_Position_Limit: 4095

--- a/wx_armor/configs/wx250s_motor_config.yaml
+++ b/wx_armor/configs/wx250s_motor_config.yaml
@@ -63,7 +63,7 @@ motors:
     ID: 1
     Baud_Rate: 3
     Return_Delay_Time: 0
-    Drive_Mode: 0
+    Drive_Mode: 4
     Velocity_Limit: 131
     Min_Position_Limit: 0
     Max_Position_Limit: 4095
@@ -73,7 +73,7 @@ motors:
     ID: 2
     Baud_Rate: 3
     Return_Delay_Time: 0
-    Drive_Mode: 0
+    Drive_Mode: 4
     Velocity_Limit: 131
     Min_Position_Limit: 819
     Max_Position_Limit: 3345
@@ -83,7 +83,7 @@ motors:
     ID: 3
     Baud_Rate: 3
     Return_Delay_Time: 0
-    Drive_Mode: 1
+    Drive_Mode: 5
     Velocity_Limit: 131
     Min_Position_Limit: 819
     Max_Position_Limit: 3345
@@ -93,7 +93,7 @@ motors:
     ID: 4
     Baud_Rate: 3
     Return_Delay_Time: 0
-    Drive_Mode: 0
+    Drive_Mode: 4
     Velocity_Limit: 131
     Min_Position_Limit: 648
     Max_Position_Limit: 3094
@@ -103,7 +103,7 @@ motors:
     ID: 5
     Baud_Rate: 3
     Return_Delay_Time: 0
-    Drive_Mode: 1
+    Drive_Mode: 5
     Velocity_Limit: 131
     Min_Position_Limit: 648
     Max_Position_Limit: 3094
@@ -113,7 +113,7 @@ motors:
     ID: 6
     Baud_Rate: 3
     Return_Delay_Time: 0
-    Drive_Mode: 0
+    Drive_Mode: 4
     Velocity_Limit: 131
     Min_Position_Limit: 0
     Max_Position_Limit: 4095
@@ -123,7 +123,7 @@ motors:
     ID: 7
     Baud_Rate: 3
     Return_Delay_Time: 0
-    Drive_Mode: 1
+    Drive_Mode: 5
     Velocity_Limit: 131
     Min_Position_Limit: 910
     Max_Position_Limit: 3447
@@ -133,7 +133,7 @@ motors:
     ID: 8
     Baud_Rate: 3
     Return_Delay_Time: 0
-    Drive_Mode: 0
+    Drive_Mode: 4
     Velocity_Limit: 131
     Min_Position_Limit: 0
     Max_Position_Limit: 4095
@@ -143,7 +143,7 @@ motors:
     ID: 9
     Baud_Rate: 3
     Return_Delay_Time: 0
-    Drive_Mode: 0
+    Drive_Mode: 4
     Velocity_Limit: 131
     Min_Position_Limit: 0
     Max_Position_Limit: 4095

--- a/wx_armor/wx_armor/wx_armor_driver.h
+++ b/wx_armor/wx_armor/wx_armor_driver.h
@@ -141,6 +141,14 @@ class WxArmorDriver {
   void SetPosition(const std::vector<float> &position);
 
   /**
+   * @brief Sets the position of the robot's joints, with a desired moving time.
+   * @param position A vector of floats representing the desired joint
+   * positions.
+   * @param moving_time A float in seconds
+   */
+  void SetPosition(const std::vector<float> &position, float moving_time);
+
+  /**
    * @brief Activates the torque in the robot's motors.
    *
    * @details When this method is called, the motors of the robot's joints start
@@ -220,6 +228,10 @@ class WxArmorDriver {
   // Similar to how we read, we also write to identical addresses on each
   // motor.
   ControlItem write_position_address_;
+
+  // Index to the write handler that writes both the position and velocity and
+  // acceleration profile, and the corresponding register addresses.
+  uint8_t write_position_and_profile_handler_index_;
 };
 
 }  // namespace horizon::wx_armor

--- a/wx_armor/wx_armor/wx_armor_ws.cc
+++ b/wx_armor/wx_armor/wx_armor_ws.cc
@@ -66,6 +66,21 @@ void WxArmorWebController::handleNewMessage(const WebSocketConnectionPtr &conn,
         position[i] = json.at(i).get<float>();
       }
       Driver()->SetPosition(position);
+    } else if (Match("MOVETO")) {
+      // Update the states for bookkeeping purpose.
+      ClientState &state = conn->getContextRef<ClientState>();
+      state.engaging = true;
+      state.latest_healthy_time = std::chrono::system_clock::now();
+
+      // Relay the command to the driver. Note that the last numbers
+      // in the list is the moving time, in seconds.
+      nlohmann::json json = nlohmann::json::parse(payload);
+      std::vector<float> position(json.size() - 1);
+      for (size_t i = 0; i < json.size() - 1; ++i) {
+        position[i] = json.at(i).get<float>();
+      }
+      float moving_time = json.at(json.size() - 1).get<float>();
+      Driver()->SetPosition(position, moving_time);
     } else if (Match("TORQUE ON")) {
       Driver()->TorqueOn();
     } else if (Match("TORQUE OFF")) {


### PR DESCRIPTION
## What is the motivation?

We want `wx_armor` to support velocity and acceleration profile, so that the user can ask the motors to move to a position within a specified moving time.

## What are changed?

1. The original `SETPOS` should remain the same
2. Added new `MOVETO` command which delegates to a new `SetPosition` method in the driver
3. Added the new `SetPosition` method, which instead of only writing `Goal Position` to each of the motors, it writes `Profile Acceleration`, `Profile Velocity` and `Goal Position` to each of the motors. 
4. Lastly, the default drive modes of each motors are changed by (+4), meaning that the profile is (more intuitively) time-based instead of velocity-based.