### PR TITLE
Set a sane default value for PID controller in wx_armor

### DIFF
--- a/configs/wx250s_motor_config.yaml
+++ b/configs/wx250s_motor_config.yaml
@@ -1,6 +1,4 @@
-# This file 'organizes' the motors in any Dynamixel-based robot into meaningful units. Every robot must
-# have at least one instance of this file located in a 'config' directory in their root 'control' ROS package.
-# Note that all parameters are mandatory unless stated otherwise. This file demos the setup for the VX300S robot.
+# This file 'organizes' the motors in any Dynamixel-based robot into meaningful units. The deployment will automatically install this file.
 #
 # Refer to http://emanual.robotis.com/#control-table to look up the control registers for the various motors.
 #
@@ -70,6 +68,8 @@ motors:
     Min_Position_Limit: 0
     Max_Position_Limit: 4095
     Secondary_ID: 255
+    Position_P_Gain: 400
+    Position_D_Gain: 3
 
   shoulder:
     ID: 2
@@ -80,6 +80,8 @@ motors:
     Min_Position_Limit: 819
     Max_Position_Limit: 3345
     Secondary_ID: 255
+    Position_P_Gain: 400
+    Position_D_Gain: 3
 
   shoulder_shadow:
     ID: 3
@@ -90,6 +92,8 @@ motors:
     Min_Position_Limit: 819
     Max_Position_Limit: 3345
     Secondary_ID: 2
+    Position_P_Gain: 400
+    Position_D_Gain: 3
 
   elbow:
     ID: 4
@@ -100,6 +104,8 @@ motors:
     Min_Position_Limit: 648
     Max_Position_Limit: 3094
     Secondary_ID: 255
+    Position_P_Gain: 400
+    Position_D_Gain: 3
 
   elbow_shadow:
     ID: 5
@@ -110,6 +116,8 @@ motors:
     Min_Position_Limit: 648
     Max_Position_Limit: 3094
     Secondary_ID: 4
+    Position_P_Gain: 400
+    Position_D_Gain: 3
 
   forearm_roll:
     ID: 6
@@ -120,6 +128,8 @@ motors:
     Min_Position_Limit: 0
     Max_Position_Limit: 4095
     Secondary_ID: 255
+    Position_P_Gain: 400
+    Position_D_Gain: 3
 
   wrist_angle:
     ID: 7
@@ -130,6 +140,8 @@ motors:
     Min_Position_Limit: 910
     Max_Position_Limit: 3447
     Secondary_ID: 255
+    Position_P_Gain: 400
+    Position_D_Gain: 3
 
   wrist_rotate:
     ID: 8
@@ -140,6 +152,8 @@ motors:
     Min_Position_Limit: 0
     Max_Position_Limit: 4095
     Secondary_ID: 255
+    Position_P_Gain: 500
+    Position_D_Gain: 0
 
   gripper:
     ID: 9
@@ -150,3 +164,5 @@ motors:
     Min_Position_Limit: 0
     Max_Position_Limit: 4095
     Secondary_ID: 255
+    Position_P_Gain: 400
+    Position_D_Gain: 3

--- a/wx_armor/configs/wx250s_motor_config.yaml
+++ b/wx_armor/configs/wx250s_motor_config.yaml
@@ -68,6 +68,8 @@ motors:
     Min_Position_Limit: 0
     Max_Position_Limit: 4095
     Secondary_ID: 255
+    Position_P_Gain: 400
+    Position_D_Gain: 3
 
   shoulder:
     ID: 2
@@ -78,6 +80,8 @@ motors:
     Min_Position_Limit: 819
     Max_Position_Limit: 3345
     Secondary_ID: 255
+    Position_P_Gain: 400
+    Position_D_Gain: 3
 
   shoulder_shadow:
     ID: 3
@@ -88,6 +92,8 @@ motors:
     Min_Position_Limit: 819
     Max_Position_Limit: 3345
     Secondary_ID: 2
+    Position_P_Gain: 400
+    Position_D_Gain: 3
 
   elbow:
     ID: 4
@@ -98,6 +104,8 @@ motors:
     Min_Position_Limit: 648
     Max_Position_Limit: 3094
     Secondary_ID: 255
+    Position_P_Gain: 400
+    Position_D_Gain: 3
 
   elbow_shadow:
     ID: 5
@@ -108,6 +116,8 @@ motors:
     Min_Position_Limit: 648
     Max_Position_Limit: 3094
     Secondary_ID: 4
+    Position_P_Gain: 400
+    Position_D_Gain: 3
 
   forearm_roll:
     ID: 6
@@ -118,6 +128,8 @@ motors:
     Min_Position_Limit: 0
     Max_Position_Limit: 4095
     Secondary_ID: 255
+    Position_P_Gain: 400
+    Position_D_Gain: 3
 
   wrist_angle:
     ID: 7
@@ -128,6 +140,8 @@ motors:
     Min_Position_Limit: 910
     Max_Position_Limit: 3447
     Secondary_ID: 255
+    Position_P_Gain: 400
+    Position_D_Gain: 3
 
   wrist_rotate:
     ID: 8
@@ -138,6 +152,8 @@ motors:
     Min_Position_Limit: 0
     Max_Position_Limit: 4095
     Secondary_ID: 255
+    Position_P_Gain: 500
+    Position_D_Gain: 0
 
   gripper:
     ID: 9
@@ -148,3 +164,5 @@ motors:
     Min_Position_Limit: 0
     Max_Position_Limit: 4095
     Secondary_ID: 255
+    Position_P_Gain: 400
+    Position_D_Gain: 3

--- a/wx_armor/wx_armor/wx_armor_driver.cc
+++ b/wx_armor/wx_armor/wx_armor_driver.cc
@@ -121,6 +121,9 @@ void FlashEEPROM(DynamixelWorkbench *dxl_wb, const RobotProfile &profile) {
           kv.motor_id,
           log);
       ++num_failed;
+    } else {
+      spdlog::info(
+          "Value '{}' of Motor {} is set to {}.", kv.key, kv.value, kv.motor_id);
     }
   }
 

--- a/wx_armor/wx_armor/wx_armor_ws.cc
+++ b/wx_armor/wx_armor/wx_armor_ws.cc
@@ -26,7 +26,7 @@ WxArmorDriver *Driver() {
                 .parent_path()
                 .parent_path() /
             "configs" / "wx250s_motor_config.yaml");
-    int flash_eeprom = GetEnv<int>("WX_ARMOR_FLASH_EEPROM", 0);
+    int flash_eeprom = true;
     int current_limit = GetEnv<int>("WX_ARMOR_MOTOR_CURRENT_LIMIT", 250);
     return std::make_unique<WxArmorDriver>(
         usb_port, motor_config, static_cast<bool>(flash_eeprom), current_limit);


### PR DESCRIPTION
1. PID controller now have sane default values for PID controller, defined in the `yaml` file
2. Add log when RAM/ROM values are changed by `FlashEEPROM`.
3. Now `FlashEEPROM` is always going to be performed (used to be guarded by an environment variable)