### PR TITLE
Support dynamically setting PID with SETPID

### DIFF
--- a/wx_armor/README.md
+++ b/wx_armor/README.md
@@ -41,8 +41,8 @@
    # Set only the "waist" motor's PID gains
    SETPID [{"name": "waist", "p": 800, "i": 0, "d": 3}]
    
-   # Set all motor's PID gains, but "wrist" will have different value
-   SETPID [{"name": "all", "p": 800, "i": 0, "d": 3}, {"name": "wrist", "p": 400, "i": 0, "d": 0}]
+   # Set all motor's PID gains, but "wrist_rotate" will have different value
+   SETPID [{"name": "all", "p": 800, "i": 0, "d": 3}, {"name": "wrist_rotate", "p": 400, "i": 0, "d": 0}]
    ```
      
 ## Deployment Guide

--- a/wx_armor/README.md
+++ b/wx_armor/README.md
@@ -33,7 +33,17 @@
    $ websocat ws://<ip>:<port>/api/engage
    ```
    
-   You can issue command like `SUBSCRIBE`, `SETPOS [<the joint positions>]`, `TORQUE ON` and `TORQUE OFF`.
+   You can issue command like `SUBSCRIBE`, `SETPOS [<the joint positions>]`, `TORQUE ON`, `TORQUE OFF`, and `SETPID`.
+   
+   The command `SETPID` is in the format of 
+   
+   ```console
+   # Set only the "waist" motor's PID gains
+   SETPID [{"name": "waist", "p": 800, "i": 0, "d": 3}]
+   
+   # Set all motor's PID gains, but "wrist" will have different value
+   SETPID [{"name": "all", "p": 800, "i": 0, "d": 3}, {"name": "wrist", "p": 400, "i": 0, "d": 0}]
+   ```
      
 ## Deployment Guide
 

--- a/wx_armor/wx_armor/wx_armor_driver.cc
+++ b/wx_armor/wx_armor/wx_armor_driver.cc
@@ -490,6 +490,8 @@ void WxArmorDriver::TorqueOff() {
 }
 
 void WxArmorDriver::SetPID(const std::vector<PIDGain> &gain_cfgs) {
+  std::lock_guard<std::mutex> lock{io_mutex_};
+
   auto SetPIDSingleMotor =
       [this](uint8_t motor_id, int32_t p, int32_t i, int32_t d) -> void {
     const char *log;

--- a/wx_armor/wx_armor/wx_armor_driver.h
+++ b/wx_armor/wx_armor/wx_armor_driver.h
@@ -81,6 +81,28 @@ struct SensorData {
 };
 
 /**
+ * @struct PIDGain
+ * @brief Holds the PID gain values for a specific motor or a group of motors.
+ *
+ * This structure is used to configure the PID gains (Proportional, Integral,
+ * Derivative) for motors in a robot. It supports setting gains by specifying
+ * motor names or applying the same gains to all motors by using "all" as the
+ * motor name.
+ */
+struct PIDGain {
+  //  The name of the motor. Use "all" to apply to all motors.
+  std::string name = "";
+  // The proportional gain for the PID controller.
+  int32_t p = 0;
+  // The integral gain for the PID controller.
+  int32_t i = 0;
+  // The derivative gain for the PID controller.
+  int32_t d = 0;
+
+  NLOHMANN_DEFINE_TYPE_INTRUSIVE(PIDGain, p, i, d);
+};
+
+/**
  * @class WxArmorDriver
  * @brief Driver class for controlling and interfacing with Dynamixel
  * motor-based robots.
@@ -174,6 +196,32 @@ class WxArmorDriver {
    * state.
    */
   void TorqueOff();
+
+  /**
+   * @brief Sets the PID gains for one or more motors based on the provided
+   * configurations.
+   *
+   * This function iterates through a list of PIDGain configurations,
+   * applying each configuration to the specified motor or all motors.
+   * If a motor's name does not match any in the profile or if "all"
+   * is specified but some motors cannot be configured, an error is
+   * logged. The function aims for flexible and efficient PID
+   * configuration across different motors in a robot using Dynamixel
+   * actuators.
+   *
+   * @param gain_cfgs A vector of PIDGain structures containing the gain
+   * configurations for the motors. Each structure specifies a motor name and
+   * the PID gains to apply. If the name is "all", the gains are applied to all
+   * motors.
+   *
+   * Usage Examples:
+   *     - To set PID gains for a specific motor: [{"name": "waist", "p":
+   * 800, "i": 0, "d": 3}]
+   *     - To set PID gains for all motors, with a different configuration for one
+   * motor: [{"name": "all", "p": 800, "i": 0, "d": 3}, {"name": "wrist",
+   * "p": 400, "i": 0, "d": 0}]
+   */
+  void SetPID(const std::vector<PIDGain> &gain_cfgs);
 
  private:
   ControlItem AddItemToRead(const std::string &name);

--- a/wx_armor/wx_armor/wx_armor_driver.h
+++ b/wx_armor/wx_armor/wx_armor_driver.h
@@ -99,7 +99,7 @@ struct PIDGain {
   // The derivative gain for the PID controller.
   int32_t d = 0;
 
-  NLOHMANN_DEFINE_TYPE_INTRUSIVE(PIDGain, p, i, d);
+  NLOHMANN_DEFINE_TYPE_INTRUSIVE(PIDGain, name, p, i, d);
 };
 
 /**

--- a/wx_armor/wx_armor/wx_armor_ws.cc
+++ b/wx_armor/wx_armor/wx_armor_ws.cc
@@ -85,6 +85,9 @@ void WxArmorWebController::handleNewMessage(const WebSocketConnectionPtr &conn,
       Driver()->TorqueOn();
     } else if (Match("TORQUE OFF")) {
       Driver()->TorqueOff();
+    } else if (Match("SETPID")) {
+      std::vector<PIDGain> gain_cfgs = nlohmann::json::parse(payload);
+      Driver()->SetPID(gain_cfgs);
     }
   }
 }


### PR DESCRIPTION
# Support `SETPID` on the fly

## Overview

The `SetPID` member function of the `WxArmorDriver` class configures Proportional-Integral-Derivative (PID) controller gains for motors in a robot using Dynamixel actuators. The function takes a vector of `PIDGain` structures, each specifying the PID gains for one or more motors identified by name. This function allows for flexible PID configuration, enabling the user to adjust the behavior of the motors for precision control.

## Parameters

- **`gain_cfgs`**: A `std::vector<PIDGain>` containing the configuration for one or more motors. Each `PIDGain` structure includes:
  - **`name`**: A `std::string` identifier for the motor(s). If the value is `"all"`, the specified PID gains will be applied to all motors. Otherwise, it targets the motor with the corresponding name.
  - **`p`**: An `int32_t` specifying the proportional gain.
  - **`i`**: An `int32_t` specifying the integral gain.
  - **`d`**: An `int32_t` specifying the derivative gain.

## Return Type

- **`void`**: This function does not return a value.

## Behavior

The function iterates through each `PIDGain` in `gain_cfgs`. Based on the `name` field, it either applies the PID gains to all motors (if `name` equals `"all"`) or to a specific motor identified by name. The actual setting of the PID gains is performed by calling a lambda function `SetPIDSingleMotor`, which writes the gains to the specified motor using the `dxl_wb_` object's `itemWrite` method.

If the specified motor name does not exist in the robot's profile, an error is logged. Similarly, errors during the writing of PID gains are logged with detailed messages.

## Examples

### Set PID Gains for a Single Motor

To set the PID gains specifically for the "waist" motor:

```cpp
SETPID [{"name": "waist", "p": 800, "i": 0, "d": 3}]
```

This command applies the PID gains (P=800, I=0, D=3) to the motor named "waist".

### Set PID Gains for All Motors, with Exception

To set the PID gains for all motors to P=800, I=0, D=3, but with different gains for the "wrist" motor:

```cpp
SETPID [{"name": "all", "p": 800, "i": 0, "d": 3}, {"name": "wrist", "p": 400, "i": 0, "d": 0}]
```

This command applies the PID gains (P=800, I=0, D=3) to all motors except for the "wrist" motor, which is set to have P=400, I=0, D=0 instead.

## Remarks

- The function relies on the `dxl_wb_` object for communication with the motors. It's assumed that this object is correctly initialized and configured to communicate with the Dynamixel actuators.
- Error handling is done through logging, making it essential for the calling process to monitor the log for any issues during the PID configuration process.
- The function allows for bulk configuration of motors, which can significantly simplify the setup process for robots with multiple actuators.