### PR TITLE
Add velocity safety limit checker

### DIFF
--- a/configs/wx250s_motor_config.yaml
+++ b/configs/wx250s_motor_config.yaml
@@ -5,33 +5,38 @@
 # SETUP OF REGISTERS FOR THE INTERBOTIX PLATFORMS
 #
 # All registers were left to their default values except for the ones listed here:
-#   1) ID.........................The ID of the Dynamixel servo. Valids IDs go from 1 - 251.
-#   2) Baud_Rate..................The speed at which serial communication occurs. All motors have this set to 1M
-#                                 baud (corresponds to a register value of '3')
-#   3) Return_Delay_Time..........The amount of time the servo delays in sending a reply packet after receiving a
-#                                 command packet. A value of '0' tells the servo to send a reply without any delay.
-#   4) Drive_Mode:................Used to define what direction is positive rotation. A value of '0' means CCW is
-#                                 positive while a value of '1' means CW is positive. It also defines if profiles are
-#                                 built based on velocity or time. 'Velocity' is the default (value of '0') and 'Time'
-#                                 is a value of '4'. Adding the 'direction' value to the 'profile' value gives the
-#                                 appropiate register value
-#   5) Velocity_Limit.............Defines the max speed of the motor. A value of '131' correpsonds to a max speed
-#                                 of PI rad/s
-#   6) Min_Position_Limit.........Defines the minimum limit of a joint. Values range from 0 to 4095 with 2048
-#                                 being equivalent to '0' rad and 0 being '-PI' rad.
-#   7) Max_Position_Limit.........Defines the maximum limit of a joint. Values range from 0 to 4095 with 2048
-#                                 being equivalent to '0' rad and 4095 being 'PI' rad.
-#   8) Secondary_ID...............If a joint is controlled by two motors (usually by the shoulder or elbow), one motor
-#                                 can be set to follow the commands of another motor by setting this register to the ID
-#                                 of the master. A value of '255' disables this.
+#   1) ID............................The ID of the Dynamixel servo. Valid IDs range from 1 to 251.
+#   2) Baud_Rate.....................The speed at which serial communication occurs. All motors have this set to 1M
+#                                    baud (corresponds to a register value of '3')
+#   3) Return_Delay_Time.............The amount of time the servo delays in sending a reply packet after receiving a
+#                                    command packet. A value of '0' tells the servo to send a reply without any delay.
+#   4) Drive_Mode:...................Used to define what direction is positive rotation. A value of '0' means CCW is
+#                                    positive while a value of '1' means CW is positive. It also defines if profiles are
+#                                    built based on velocity or time. 'Velocity' is the default (value of '0') and 'Time'
+#                                    is a value of '4'. Adding the 'direction' value to the 'profile' value gives the
+#                                    appropriate register value
+#   5) Velocity_Limit................Defines the max speed of the motor. A value of '131' corresponds to a max speed
+#                                    of PI rad/s. NOTE: this is only used in velocity control mode. I.e., has no effect
+#                                    in the default position control setting.
+#   6) Min_Position_Limit............Defines the minimum limit of a joint. Values range from 0 to 4095 with 2048
+#                                    being equivalent to '0' rad and 0 being '-PI' rad.
+#   7) Max_Position_Limit............Defines the maximum limit of a joint. Values range from 0 to 4095 with 2048
+#                                    being equivalent to '0' rad and 4095 being 'PI' rad.
+#   8) Secondary_ID..................If a joint is controlled by two motors (usually by the shoulder or elbow), one motor
+#                                    can be set to follow the commands of another motor by setting this register to the ID
+#                                    of the master. A value of '255' disables this.
+#   9) Safety_Velocity_Limit.........Defines the max safety velocity limit [deg/s]. If the joint velocity ever violates
+#                                    this limit, we override the current policy and attempt to slowly decelerate to a stop.
+#   10) Safety_Acceleration_Limit....Defines the max safety acceleration limit [deg/s^2]. If the joint acceleration ever violates
+#                                    this limit, we override the current policy and attempt to slowly decelerate to a stop.
 #
 # Each motor's configs are grouped under the name of the joint the motor is controlling. The names are defined at
 # http://support.interbotix.com/ under the 'Specifications' section. (Click a robot and scroll down to the 'Default Joint Limits' section.)
 
 port: /dev/ttyDXL
 
-joint_order: [waist, shoulder, elbow, forearm_roll, wrist_angle, wrist_rotate, gripper]
-sleep_positions: [0, -1.80, 1.55, 0, 0.8, 0, 0]
+joint_order: [ waist, shoulder, elbow, forearm_roll, wrist_angle, wrist_rotate, gripper ]
+sleep_positions: [ 0, -1.80, 1.55, 0, 0.8, 0, 0 ]
 
 joint_state_publisher:
   update_rate: 1000
@@ -39,7 +44,7 @@ joint_state_publisher:
   topic_name: joint_states
 
 groups:
-  arm: [waist, shoulder, elbow, forearm_roll, wrist_angle, wrist_rotate, gripper]
+  arm: [ waist, shoulder, elbow, forearm_roll, wrist_angle, wrist_rotate, gripper ]
 
 grippers:
   gripper:
@@ -50,10 +55,10 @@ grippers:
 
 shadows:
   shoulder:
-    shadow_list: [shoulder_shadow]
+    shadow_list: [ shoulder_shadow ]
     calibrate: true
   elbow:
-    shadow_list: [elbow_shadow]
+    shadow_list: [ elbow_shadow ]
     calibrate: true
 
 sisters:
@@ -70,6 +75,7 @@ motors:
     Secondary_ID: 255
     Position_P_Gain: 400
     Position_D_Gain: 3
+    Safety_Velocity_Limit: 90
 
   shoulder:
     ID: 2
@@ -82,6 +88,7 @@ motors:
     Secondary_ID: 255
     Position_P_Gain: 400
     Position_D_Gain: 3
+    Safety_Velocity_Limit: 90
 
   shoulder_shadow:
     ID: 3
@@ -94,6 +101,7 @@ motors:
     Secondary_ID: 2
     Position_P_Gain: 400
     Position_D_Gain: 3
+    Safety_Velocity_Limit: 90
 
   elbow:
     ID: 4
@@ -106,6 +114,7 @@ motors:
     Secondary_ID: 255
     Position_P_Gain: 400
     Position_D_Gain: 3
+    Safety_Velocity_Limit: 90
 
   elbow_shadow:
     ID: 5
@@ -118,6 +127,7 @@ motors:
     Secondary_ID: 4
     Position_P_Gain: 400
     Position_D_Gain: 3
+    Safety_Velocity_Limit: 90
 
   forearm_roll:
     ID: 6
@@ -130,6 +140,7 @@ motors:
     Secondary_ID: 255
     Position_P_Gain: 400
     Position_D_Gain: 3
+    Safety_Velocity_Limit: 90
 
   wrist_angle:
     ID: 7
@@ -142,6 +153,7 @@ motors:
     Secondary_ID: 255
     Position_P_Gain: 400
     Position_D_Gain: 3
+    Safety_Velocity_Limit: 90
 
   wrist_rotate:
     ID: 8
@@ -154,6 +166,7 @@ motors:
     Secondary_ID: 255
     Position_P_Gain: 500
     Position_D_Gain: 0
+    Safety_Velocity_Limit: 90
 
   gripper:
     ID: 9
@@ -166,3 +179,4 @@ motors:
     Secondary_ID: 255
     Position_P_Gain: 400
     Position_D_Gain: 3
+    Safety_Velocity_Limit: 90

--- a/configs/wx250s_motor_config.yaml
+++ b/configs/wx250s_motor_config.yaml
@@ -27,8 +27,10 @@
 #                                    of the master. A value of '255' disables this.
 #   9) Safety_Velocity_Limit.........Defines the max safety velocity limit [deg/s]. If the joint velocity ever violates
 #                                    this limit, we override the current policy and attempt to slowly decelerate to a stop.
+#                                    Note that for shadowed motors, though an entry is still expected, this value is unused.
 #   10) Safety_Acceleration_Limit....Defines the max safety acceleration limit [deg/s^2]. If the joint acceleration ever violates
 #                                    this limit, we override the current policy and attempt to slowly decelerate to a stop.
+#                                    Note that for shadowed motors, though an entry is still expected, this value is unused.
 #
 # Each motor's configs are grouped under the name of the joint the motor is controlling. The names are defined at
 # http://support.interbotix.com/ under the 'Specifications' section. (Click a robot and scroll down to the 'Default Joint Limits' section.)

--- a/wx_armor/wx_armor/robot_profile.cc
+++ b/wx_armor/wx_armor/robot_profile.cc
@@ -12,11 +12,17 @@ bool convert<horizon::wx_armor::RobotProfile>::decode(
   for (const auto &child : node["motors"]) {
     YAML::Node info = child.second;
     uint8_t motor_id = info["ID"].as<uint8_t>();
+
+    // Safety velocity limit is given in [deg/s]. Convert it to [rad/s]
+    float safety_vel_limit = info["Safety_Velocity_Limit"].as<float>();
+    safety_vel_limit *= M_PI / 180.;
+
     profile.motors.emplace_back(MotorInfo{
         .id = motor_id,
         .name = child.first.as<std::string>(),
         // By default, set the operation mode to position control.
         .op_mode = OpMode::POSITION,
+        .safety_vel_limit = safety_vel_limit
     });
 
     // Now, populate the register table.

--- a/wx_armor/wx_armor/robot_profile.h
+++ b/wx_armor/wx_armor/robot_profile.h
@@ -29,6 +29,7 @@
 #include <map>
 #include <string_view>
 #include <vector>
+#include <math.h>
 
 #include "yaml-cpp/yaml.h"
 
@@ -68,9 +69,12 @@ struct MotorInfo {
   // The following information are currently not used at this moment. Having
   // them here just to be consistent with dynamixel.
   OpMode op_mode = OpMode::POSITION;
+
+  // The safety velocity limit in [rad/s]
+  float safety_vel_limit = M_PI / 2;
 };
 
-// The EERPROM area of each motor is logically organized as a a few key/value
+// The EERPROM area of each motor is logically organized as a few key/value
 // pairs, similar to a registry. This class is used to represent such a
 // key/value pair, together with their associated motor ID.
 struct RegistryKV {

--- a/wx_armor/wx_armor/wx_armor_driver.cc
+++ b/wx_armor/wx_armor/wx_armor_driver.cc
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <cstdlib>
 #include <thread>
+#include <cassert>
 
 #include "spdlog/spdlog.h"
 
@@ -103,6 +104,12 @@ void FlashEEPROM(DynamixelWorkbench *dxl_wb, const RobotProfile &profile) {
   size_t num_failed = 0;
   for (const RegistryKV &kv : profile.eeprom) {
     int32_t current_value = 0;
+
+    // Hacky fix for now... Probably a better way to handle this
+    // Safety_Velocity_Limit is our own custom param. Don't write it to EEPROM
+    if (kv.key == "Safety_Velocity_Limit") {
+      continue;
+    }
     dxl_wb->itemRead(kv.motor_id, kv.key.c_str(), &current_value);
 
     // The EEPROM on the motors has a limited number of writes during its
@@ -417,6 +424,20 @@ std::optional<SensorData> WxArmorDriver::Read() {
   return std::move(result);
 }
 
+std::vector<float> WxArmorDriver::GetSafetyVelocityLimits() {
+  std::vector<float> safety_velocity_limits;
+
+  int counter = 0;
+  for (const auto &motor : profile_.motors) {
+    // Skip the shadowed motors, which have IDs 3 and 5.
+    if (counter != 3 && counter != 5) {
+      safety_velocity_limits.push_back(motor.safety_vel_limit);
+    }
+    counter++;
+  }
+  return safety_velocity_limits;
+}
+
 void WxArmorDriver::SetPosition(const std::vector<float> &position) {
   const uint8_t num_joints = static_cast<uint8_t>(profile_.joint_ids.size());
   std::vector<int32_t> int_command(num_joints, 0);
@@ -443,14 +464,18 @@ void WxArmorDriver::SetPosition(const std::vector<float> &position) {
 }
 
 void WxArmorDriver::SetPosition(const std::vector<float> &position,
-                                float moving_time) {
+                                float moving_time,
+                                float acc_time) {
+  assert(moving_time / 2 >= acc_time && "Acceleration time cannot be more than half the moving time.");
+
   int32_t moving_time_ms = static_cast<int32_t>(moving_time * 1000.0);
+  int32_t acc_time_ms = static_cast<int32_t>(acc_time * 1000.0);
   const uint8_t num_joints = static_cast<uint8_t>(profile_.joint_ids.size());
   std::vector<int32_t> int_command(num_joints * 3, 0);
   size_t j = 0;
   for (size_t i = 0; i < profile_.joint_ids.size(); ++i) {
     // Profile acceleration
-    int_command[j++] = 0;
+    int_command[j++] = acc_time_ms;
     // Profile velocity
     int_command[j++] = moving_time_ms;
     // Goal Position

--- a/wx_armor/wx_armor/wx_armor_driver.cc
+++ b/wx_armor/wx_armor/wx_armor_driver.cc
@@ -546,8 +546,20 @@ void WxArmorDriver::SetPID(const std::vector<PIDGain> &gain_cfgs) {
   }
 }
 
+bool WxArmorDriver::SafetyViolationTriggered() {
+  return safety_violation_.load();
+}
+
+void WxArmorDriver::TriggerSafetyViolationMode() {
+  safety_violation_ = true;
+}
+
+void WxArmorDriver::ResetSafetyViolationMode() {
+  safety_violation_ = false;
+}
+
 ControlItem WxArmorDriver::AddItemToRead(const std::string &name) {
-  // Here we assume that the data allocation on all of the motors are
+  // Here we assume that the data allocation on all the motors are
   // identical. Therefore, we can just read the address of the motor ID and
   // call it a day.
   const ControlItem *address =

--- a/wx_armor/wx_armor/wx_armor_driver.h
+++ b/wx_armor/wx_armor/wx_armor_driver.h
@@ -156,6 +156,13 @@ class WxArmorDriver {
   std::optional<SensorData> Read();
 
   /**
+   * @brief Reads the safety velocity limits from RobotProfile and returns it.
+   *
+   * @return An array containing the safety velocity limits for each motor [rad/s].
+   */
+   std::vector<float> GetSafetyVelocityLimits();
+
+  /**
    * @brief Sets the position of the robot's joints.
    * @param position A vector of floats representing the desired joint
    * positions.
@@ -163,12 +170,15 @@ class WxArmorDriver {
   void SetPosition(const std::vector<float> &position);
 
   /**
-   * @brief Sets the position of the robot's joints, with a desired moving time.
+   * @brief Sets the position of the robot's joints, with a desired moving and 
+   * acceleration time.
+   * @details If acc_time is zero, constant velocity is used.
    * @param position A vector of floats representing the desired joint
    * positions.
    * @param moving_time A float in seconds
+   * @param acc_time A float in seconds
    */
-  void SetPosition(const std::vector<float> &position, float moving_time);
+  void SetPosition(const std::vector<float> &position, float moving_time, float acc_time=0.0);
 
   /**
    * @brief Activates the torque in the robot's motors.

--- a/wx_armor/wx_armor/wx_armor_driver.h
+++ b/wx_armor/wx_armor/wx_armor_driver.h
@@ -233,6 +233,30 @@ class WxArmorDriver {
    */
   void SetPID(const std::vector<PIDGain> &gain_cfgs);
 
+  /**
+   * @brief Returns the current safety violation mode status.
+   *
+   * @return A bool describing whether a safety violation is currently
+   * triggered and not reset.
+   */
+  bool SafetyViolationTriggered();
+
+  /**
+   * @brief Sets off safety violation mode.
+   *
+   * @details For functionality to return to normal, ResetSafetyViolation()
+   * must be called.
+   */
+  void TriggerSafetyViolationMode();
+
+  /**
+   * @brief Resets the safety violation status back to false.
+   *
+   * @note Currently, this gets called only when a new client connection
+   * is made after all previous connections are closed.
+   */
+  void ResetSafetyViolationMode();
+
  private:
   ControlItem AddItemToRead(const std::string &name);
 
@@ -290,6 +314,11 @@ class WxArmorDriver {
   // Index to the write handler that writes both the position and velocity and
   // acceleration profile, and the corresponding register addresses.
   uint8_t write_position_and_profile_handler_index_;
+
+  // Flag that gets triggered when safety violations such as
+  // velocity limits are violated.
+  std::atomic_bool safety_violation_{false};
+
 };
 
 }  // namespace horizon::wx_armor

--- a/wx_armor/wx_armor/wx_armor_ws.cc
+++ b/wx_armor/wx_armor/wx_armor_ws.cc
@@ -15,6 +15,10 @@ using drogon::WebSocketMessageType;
 
 namespace horizon::wx_armor {
 
+// Global flag that gets triggered when safety violations such as
+// velocity limits are violated.
+bool safety_violation = false;
+
 WxArmorDriver *Driver() {
   static std::unique_ptr<WxArmorDriver> driver = []() {
     std::string usb_port =
@@ -38,6 +42,12 @@ void WxArmorWebController::handleNewMessage(const WebSocketConnectionPtr &conn,
                                             std::string &&message,
                                             const WebSocketMessageType &type) {
   std::string_view payload{};
+
+  if (safety_violation) {
+    spdlog::error(
+        "Call from message handler ignored. Safety violation was encountered.");
+    return;
+  }
 
   // Valid message should be in the format of "<COMMAND> <PAYLOAD>". This helper
   // function try to match the message with predefined command, and if there is
@@ -108,10 +118,32 @@ void WxArmorWebController::handleNewConnection(
 
 static constexpr int MAX_TOLERABLE_CONSECUTIVE_NUM_READ_ERRORS = 6;
 
+void slowDownToStop(const SensorData &curr_reading,
+                    float dt = 0.5,
+                    float deceleration_time = 1.5) {
+  std::vector<float> curr_pos = curr_reading.pos;
+  std::vector<float> curr_vel = curr_reading.vel;
+  std::vector<float> targets;
+
+  for (size_t i = 0; i < curr_pos.size(); i++) {
+    // Just some simple kinematic integration to minimize acceleration changes
+    float curr_target = curr_pos[i] + curr_vel[i] * dt;
+    targets.push_back(curr_target);
+  }
+
+  // Overwrite the current trajectory with our decelerating one.
+  Driver()->SetPosition(targets, deceleration_time, 0.49 * deceleration_time);
+}
+
 WxArmorWebController::Publisher::Publisher() {
   thread_ = std::jthread([this]() {
+    std::vector<float> safety_velocity_limits =
+        Driver()->GetSafetyVelocityLimits();
     while (!shutdown_.load()) {
+      // Read the sensor data
       std::optional<SensorData> sensor_data = Driver()->Read();
+
+      // Publish the sensor data
       if (sensor_data.has_value()) {
         num_consecutive_read_errors_ = 0;
         std::string message = nlohmann::json(sensor_data.value()).dump();
@@ -119,6 +151,36 @@ WxArmorWebController::Publisher::Publisher() {
         for (const WebSocketConnectionPtr &conn : conns_) {
           conn->send(message);
         }
+
+        // Don't check for a new safety violation if state hasn't been reset yet
+        if (safety_violation) {
+          spdlog::error(
+              "Call from publisher handler ignored. Safety violation was "
+              "encountered.");
+          continue;
+        }
+
+        // Publisher also has the dual role of monitoring for safety
+        // e.g., checking for velocity limit violations
+        std::vector<float> curr_velocities = sensor_data.value().vel;
+        for (int i = 0; i < curr_velocities.size(); i++) {
+          float cv = fabs(curr_velocities[i]);
+          float limit = safety_velocity_limits[i];
+          if (cv > limit) {
+            safety_violation = true;
+            break;
+          }
+        }
+
+        // If a safety violation is triggered, first slow down to a stop
+        // and then kill all client connections.
+        // This way, user will have to reset on client-side, but the server
+        // will keep running.
+        if (safety_violation) {
+          slowDownToStop(sensor_data.value());
+          _KillConnections();
+        }
+
       } else {
         // When fail to read, accumulate the counter, check for threshold and
         // crash if threshold is exceeded.
@@ -146,6 +208,10 @@ WxArmorWebController::Publisher::~Publisher() {
 
 void WxArmorWebController::Publisher::Subscribe(
     const WebSocketConnectionPtr &conn) {
+  // Clear all safety violations only if there are no previous connections
+  if (conns_.empty()) {
+    safety_violation = false;
+  }
   std::lock_guard<std::mutex> lock{conns_mutex_};
   conns_.emplace_back(conn);
 }
@@ -154,6 +220,14 @@ void WxArmorWebController::Publisher::Unsubscribe(
     const WebSocketConnectionPtr &conn) {
   std::lock_guard<std::mutex> lock{conns_mutex_};
   conns_.erase(std::remove(conns_.begin(), conns_.end(), conn), conns_.end());
+}
+
+void WxArmorWebController::Publisher::_KillConnections() {
+  for (auto &conn : conns_) {
+    conn->clearContext();
+    conn->forceClose();
+  }
+  conns_.clear();
 }
 
 }  // namespace horizon::wx_armor

--- a/wx_armor/wx_armor/wx_armor_ws.cc
+++ b/wx_armor/wx_armor/wx_armor_ws.cc
@@ -220,8 +220,9 @@ void WxArmorWebController::GuardianThread::Unsubscribe(
 
 void WxArmorWebController::GuardianThread::KillConnections() {
   for (auto &conn : conns_) {
-    conn->clearContext();
-    conn->forceClose();
+    // TODO(andrew): log which joint was responsible?
+    conn->shutdown(drogon::CloseCode::kViolation,
+                   "Shutting down due to velocity limit violation.");
   }
   conns_.clear();
 }

--- a/wx_armor/wx_armor/wx_armor_ws.h
+++ b/wx_armor/wx_armor/wx_armor_ws.h
@@ -61,10 +61,10 @@ class WxArmorWebController
     Publisher();
     ~Publisher();
 
-    // Add the client (identified by the connection) to the subscribption list.
+    // Add the client (identified by the connection) to the subscription list.
     void Subscribe(const drogon::WebSocketConnectionPtr &conn);
 
-    // Remove the client (identified by the connection) to the subscribption
+    // Remove the client (identified by the connection) to the subscription
     // list.
     void Unsubscribe(const drogon::WebSocketConnectionPtr &conn);
 
@@ -74,6 +74,9 @@ class WxArmorWebController
 
     std::atomic_bool shutdown_{false};
     std::jthread thread_{};
+
+    // Close and remove all client connections from subscription list
+    void _KillConnections();
 
     // Book keeping of the number of read errors in a row. Reset to 0 as soon as
     // a successful read is seen. Server will crash as soon as this number

--- a/wx_armor/wx_armor/wx_armor_ws.h
+++ b/wx_armor/wx_armor/wx_armor_ws.h
@@ -53,13 +53,14 @@ class WxArmorWebController
   WS_PATH_LIST_END
 
  private:
-  // The publisher is responsible for continuously (by running a background
+  // The GuardianThread is responsible for 1) continuously (by running a background
   // thread) read the sensor data and publish it to the clients that subscribe
-  // the sensor data.
-  class Publisher {
+  // the sensor data and 2) monitoring for safety violations and notifying
+  // WxArmorDriver accordingly to prevent system damage.
+  class GuardianThread {
    public:
-    Publisher();
-    ~Publisher();
+    GuardianThread();
+    ~GuardianThread();
 
     // Add the client (identified by the connection) to the subscription list.
     void Subscribe(const drogon::WebSocketConnectionPtr &conn);
@@ -76,7 +77,7 @@ class WxArmorWebController
     std::jthread thread_{};
 
     // Close and remove all client connections from subscription list
-    void _KillConnections();
+    void KillConnections();
 
     // Book keeping of the number of read errors in a row. Reset to 0 as soon as
     // a successful read is seen. Server will crash as soon as this number
@@ -84,7 +85,7 @@ class WxArmorWebController
     int num_consecutive_read_errors_ = 0;
   };
 
-  Publisher publisher_;
+  GuardianThread guardian_thread_;
 };
 
 // Helper function to read the environment variable.


### PR DESCRIPTION
Velocity limits can now be specified for position control mode in the yaml file as `Safety_Velocity_Limit` entries. Designed so that when any limit is violated, the arm will slow down to a stop and close all client connections. To avoid large (potentially damaging) decelerations, we decelerate along a kinematic integrated path. 

With the current design, the driver will always stay alive and will only reset its safety violation status if a new connection is made while there are zero current connections. This can simply be achieved by restarting the policy on the client-side.

This functionality was tested using some "unit test" policies in the Hobot deployment branch. Those can be PRed later.