### PR TITLE
Upgrade driver to support controller mode other than position control

### DIFF
--- a/wx_armor/wx_armor/robot_profile.cc
+++ b/wx_armor/wx_armor/robot_profile.cc
@@ -17,13 +17,12 @@ bool convert<horizon::wx_armor::RobotProfile>::decode(
     float safety_vel_limit = info["Safety_Velocity_Limit"].as<float>();
     safety_vel_limit *= M_PI / 180.;
 
-    profile.motors.emplace_back(MotorInfo{
-        .id = motor_id,
-        .name = child.first.as<std::string>(),
-        // By default, set the operation mode to position control.
-        .op_mode = OpMode::POSITION,
-        .safety_vel_limit = safety_vel_limit
-    });
+    profile.motors.emplace_back(
+        MotorInfo{.id = motor_id,
+                  .name = child.first.as<std::string>(),
+                  // By default, set the operation mode to position control.
+                  .op_mode = OpMode::POSITION,
+                  .safety_vel_limit = safety_vel_limit});
 
     // Now, populate the register table.
     for (const auto &kv : info) {
@@ -46,6 +45,7 @@ bool convert<horizon::wx_armor::RobotProfile>::decode(
           name);
     }
     profile.joint_ids.emplace_back(motor->id);
+    profile.joint_motors.emplace_back(motor);
     profile.joint_names.emplace_back(motor->name);
   }
 
@@ -101,8 +101,6 @@ std::string_view OpModeName(OpMode mode) {
       return "CURRENT_BASED_POSITION";
     case OpMode::PWM:
       return "PWM";
-    case OpMode::TORQUE:
-      return "TORQUE";
   }
   return "UNKNOWN";
 }


### PR DESCRIPTION
Recently we are planning to use torque control for the gripper motor, while keeping all the rest of the motors with position control.

Previously, only position control is supported in the "wx armor" driver. This PR extends it so that current control, velocity control and PWM control are now supported. Specifically, a flag (environment variable) is introduced to turn on "PWM control" for the gripper, which approximately resembles the torque control.

The following changes are made to implement the above idea:

1. In profile, now `joint_motors` are added so that we can directly iterate over the (main) motor of each joint.
2. `TORQUE` control mode is removed from `OpMode` because it is not supported by the hardware.
3. Environment variable `WX_ARMOR_GRIPPER_PWM_CTRL` is introduced as the flag to turn PWM control on gripper on and off.
4. The `syncWrite` is now writing 5 bytes on each motor instead of 3 bytes. The two extra bytes are for the goal PWM, goal current and goal velocity.
5. `SetPosition` is renamed to `SendCommand` as it is no longer position control only.
6. Since we now have 5 bytes per motor to worry about, the code is refactored so that the `SendCommand` and `InitWriteHandler` is clearner. Specifically, which goal to set is now purely based on the `OpMode` of the motor.