### PR TITLE
Add gripper closing delta control logic to alleviate faults

### DIFF
--- a/wx_armor/configs/wx250s_motor_config.yaml
+++ b/wx_armor/configs/wx250s_motor_config.yaml
@@ -210,10 +210,10 @@ motors:
     Return_Delay_Time: 0
     Drive_Mode: 4
     Velocity_Limit: 131
-    Current_Limit: 1193
+    Current_Limit: 800
     Min_Position_Limit: 0
     Max_Position_Limit: 4095
     Secondary_ID: 255
     Position_P_Gain: 400
-    Position_D_Gain: 0
+    Position_D_Gain: 3
     Safety_Velocity_Limit: 10

--- a/wx_armor/configs/wx250s_motor_config.yaml
+++ b/wx_armor/configs/wx250s_motor_config.yaml
@@ -208,10 +208,10 @@ motors:
     Return_Delay_Time: 0
     Drive_Mode: 4
     Velocity_Limit: 131
-    Current_Limit: 800
+    Current_Limit: 1193
     Min_Position_Limit: 0
     Max_Position_Limit: 4095
     Secondary_ID: 255
     Position_P_Gain: 400
-    Position_D_Gain: 3
+    Position_D_Gain: 0
     Safety_Velocity_Limit: 10

--- a/wx_armor/configs/wx250s_motor_config.yaml
+++ b/wx_armor/configs/wx250s_motor_config.yaml
@@ -55,6 +55,8 @@ port: /dev/ttyDXL
 joint_order: [ waist, shoulder, elbow, forearm_roll, wrist_angle, wrist_rotate, gripper ]
 sleep_positions: [ 0, -1.80, 1.55, 0, 0.8, 0, 0 ]
 
+gripper_closing_iters: 3
+
 joint_state_publisher:
   update_rate: 1000
   publish_states: true

--- a/wx_armor/wx_armor/guardian_thread.cc
+++ b/wx_armor/wx_armor/guardian_thread.cc
@@ -160,6 +160,7 @@ void GuardianThread::ResetErrorCodes() {
         error_code = 0;
     }
     Driver()->ResetSafetyViolationMode();
+    Driver()->ResetGripperClosingCounter();
 }
 
 void GuardianThread::SetErrorCode(uint8_t motor_idx, int32_t error_code, bool is_joint_idx) {

--- a/wx_armor/wx_armor/guardian_thread.cc
+++ b/wx_armor/wx_armor/guardian_thread.cc
@@ -160,7 +160,6 @@ void GuardianThread::ResetErrorCodes() {
         error_code = 0;
     }
     Driver()->ResetSafetyViolationMode();
-    Driver()->ResetGripperClosingCounter();
 }
 
 void GuardianThread::SetErrorCode(uint8_t motor_idx, int32_t error_code, bool is_joint_idx) {

--- a/wx_armor/wx_armor/robot_profile.cc
+++ b/wx_armor/wx_armor/robot_profile.cc
@@ -59,6 +59,8 @@ bool convert<horizon::wx_armor::RobotProfile>::decode(const Node& node,
         }
     }
 
+    profile.gripper_closing_iters = node["gripper_closing_iters"].as<uint32_t>();
+
     // Fill in joint IDs.
     for (const auto& child : node["joint_order"]) {
         std::string name = child.as<std::string>();

--- a/wx_armor/wx_armor/robot_profile.h
+++ b/wx_armor/wx_armor/robot_profile.h
@@ -117,6 +117,7 @@ struct RobotProfile
     std::vector<uint8_t> joint_ids{};
     std::vector<std::string> joint_names{};
     std::vector<RegistryKV> eeprom{};
+    uint32_t gripper_closing_iters;
 
     RobotProfile() = default;
     RobotProfile(RobotProfile&&) = default;

--- a/wx_armor/wx_armor/wx_armor_driver.cc
+++ b/wx_armor/wx_armor/wx_armor_driver.cc
@@ -460,7 +460,7 @@ void WxArmorDriver::SetPosition(const std::vector<float>& position, float moving
     }
     // Here, the gripper is closing.
     else {
-        if (closing_iters_ >= 1) {
+        if (closing_iters_ >= profile_.gripper_closing_iters) {
             // After closing for a set number of iterations, we can alleviate
             // the grasp to a less aggressive position goal to prevent
             // gripper motor overload.
@@ -469,7 +469,8 @@ void WxArmorDriver::SetPosition(const std::vector<float>& position, float moving
             float gripper_target = std::max(gripper_position_.load() - 0.1, 0.0);
 
             // Override the gripper target position
-            int_command[--j] = dxl_wb_.convertRadian2Value(profile_.joint_ids[gi], gripper_target);
+            int_command[j - 1] =
+                dxl_wb_.convertRadian2Value(profile_.joint_ids[gi], gripper_target);
         }
         closing_iters_++;
     }

--- a/wx_armor/wx_armor/wx_armor_driver.h
+++ b/wx_armor/wx_armor/wx_armor_driver.h
@@ -342,7 +342,7 @@ class WxArmorDriver
 
     // The current gripper position to be updated by Read().
     // Used for delta control when gripper is closing.
-    std::atomic<double> gripper_position_{1.0};
+    double gripper_position_{1.0};
 };
 
 // Helper function to read the environment variable.

--- a/wx_armor/wx_armor/wx_armor_driver.h
+++ b/wx_armor/wx_armor/wx_armor_driver.h
@@ -345,7 +345,7 @@ class WxArmorDriver
 
     // A tracker for how many iterations the gripper has been closing for
     // without an open command.
-    int32_t closing_iters_{0};
+    uint32_t closing_iters_{0};
 
     // The current gripper position to be updated by Read().
     // Used for delta control when gripper is closing.

--- a/wx_armor/wx_armor/wx_armor_driver.h
+++ b/wx_armor/wx_armor/wx_armor_driver.h
@@ -262,6 +262,13 @@ class WxArmorDriver
     void ResetSafetyViolationMode();
 
     /**
+     * @brief Resets the gripper delta counter to 0
+     */
+    void ResetGripperClosingCounter() {
+        closing_iters_ = 0;
+    }
+
+    /**
      * @brief Returns the profile of the robot.
      */
     const RobotProfile& Profile() const {
@@ -335,6 +342,14 @@ class WxArmorDriver
     // Flag that gets triggered when safety violations such as
     // velocity limits are violated.
     std::atomic_bool safety_violation_{false};
+
+    // A tracker for how many iterations the gripper has been closing for
+    // without an open command.
+    int32_t closing_iters_{0};
+
+    // The current gripper position to be updated by Read().
+    // Used for delta control when gripper is closing.
+    std::atomic<double> gripper_position_{1.0};
 };
 
 // Helper function to read the environment variable.

--- a/wx_armor/wx_armor/wx_armor_driver.h
+++ b/wx_armor/wx_armor/wx_armor_driver.h
@@ -262,13 +262,6 @@ class WxArmorDriver
     void ResetSafetyViolationMode();
 
     /**
-     * @brief Resets the gripper delta counter to 0
-     */
-    void ResetGripperClosingCounter() {
-        closing_iters_ = 0;
-    }
-
-    /**
      * @brief Returns the profile of the robot.
      */
     const RobotProfile& Profile() const {


### PR DESCRIPTION
This PR adds the delta logic for when the gripper is closing to prevent faults when grasping large objects. After a set number of iterations closing (currently 5), the position goal of the gripper will be reset to the current position - 0.1. From my tests, it's crucial for the the closing gripper position to match the policy's output at least for a certain number of iterations, otherwise the grasping dynamics change and task failure arises.

Note that this was only tested with elongated gripper which has a higher tolerance to faulting than standard gripper. Because of this the -0.1 delta has to be tested for standard gripper. In fact, for elongated gripper, I confirmed that even the current position itself succeeds since the fingers for elongated bend inward when grasping. We may want to wait to merge this PR until we test it using the standard gripper.

Below is a terminal output of a test for grasping showing the gripper goal position and the current closing iteration. Notice that after closing for a while, the gripper position alleviates from ~0 to ~0.40.

![delta_control](https://github.com/HorizonRoboticsInternal/interbotix_xs_driver/assets/43973701/54b2297f-12eb-4218-9d05-28a0a4ae6115)
