### PR TITLE
Add per-motor config logic for current-based position control

### DIFF
--- a/wx_armor/configs/wx250s_motor_config.yaml
+++ b/wx_armor/configs/wx250s_motor_config.yaml
@@ -18,17 +18,21 @@
 #   5) Velocity_Limit................Defines the max speed of the motor. A value of '131' corresponds to a max speed
 #                                    of PI rad/s. NOTE: this is only used in velocity control mode. I.e., has no effect
 #                                    in the default position control setting.
-#   6) Min_Position_Limit............Defines the minimum limit of a joint. Values range from 0 to 4095 with 2048
+#   6) Current_Limit.................Defines the current limit of the motor. Any value > 0 will cause the motor to operate
+#                                    in current-based position control mode with the specified current limit. A value of 0
+#                                    defaults to normal position control.
+#                                    in the default position control setting.
+#   7) Min_Position_Limit............Defines the minimum limit of a joint. Values range from 0 to 4095 with 2048
 #                                    being equivalent to '0' rad and 0 being '-PI' rad.
-#   7) Max_Position_Limit............Defines the maximum limit of a joint. Values range from 0 to 4095 with 2048
+#   8) Max_Position_Limit............Defines the maximum limit of a joint. Values range from 0 to 4095 with 2048
 #                                    being equivalent to '0' rad and 4095 being 'PI' rad.
-#   8) Secondary_ID..................If a joint is controlled by two motors (usually by the shoulder or elbow), one motor
+#   9) Secondary_ID..................If a joint is controlled by two motors (usually by the shoulder or elbow), one motor
 #                                    can be set to follow the commands of another motor by setting this register to the ID
 #                                    of the master. A value of '255' disables this.
-#   9) Safety_Velocity_Limit.........Defines the max safety velocity limit [deg/s]. If the joint velocity ever violates
+#  10) Safety_Velocity_Limit.........Defines the max safety velocity limit [deg/s]. If the joint velocity ever violates
 #                                    this limit, we override the current policy and attempt to slowly decelerate to a stop.
 #                                    Note that for shadowed motors, though an entry is still expected, this value is unused.
-#   10) Safety_Acceleration_Limit....Defines the max safety acceleration limit [deg/s^2]. If the joint acceleration ever violates
+#   11) Safety_Acceleration_Limit....Defines the max safety acceleration limit [deg/s^2]. If the joint acceleration ever violates
 #                                    this limit, we override the current policy and attempt to slowly decelerate to a stop.
 #                                    Note that for shadowed motors, though an entry is still expected, this value is unused.
 #
@@ -72,6 +76,7 @@ motors:
     Return_Delay_Time: 0
     Drive_Mode: 4
     Velocity_Limit: 131
+    Current_Limit: 0
     Min_Position_Limit: 0
     Max_Position_Limit: 4095
     Secondary_ID: 255
@@ -85,6 +90,7 @@ motors:
     Return_Delay_Time: 0
     Drive_Mode: 4
     Velocity_Limit: 131
+    Current_Limit: 0
     Min_Position_Limit: 819
     Max_Position_Limit: 3345
     Secondary_ID: 255
@@ -98,6 +104,7 @@ motors:
     Return_Delay_Time: 0
     Drive_Mode: 5
     Velocity_Limit: 131
+    Current_Limit: 0
     Min_Position_Limit: 819
     Max_Position_Limit: 3345
     Secondary_ID: 2
@@ -111,6 +118,7 @@ motors:
     Return_Delay_Time: 0
     Drive_Mode: 4
     Velocity_Limit: 131
+    Current_Limit: 0
     Min_Position_Limit: 648
     Max_Position_Limit: 3094
     Secondary_ID: 255
@@ -124,6 +132,7 @@ motors:
     Return_Delay_Time: 0
     Drive_Mode: 5
     Velocity_Limit: 131
+    Current_Limit: 0
     Min_Position_Limit: 648
     Max_Position_Limit: 3094
     Secondary_ID: 4
@@ -137,6 +146,7 @@ motors:
     Return_Delay_Time: 0
     Drive_Mode: 4
     Velocity_Limit: 131
+    Current_Limit: 0
     Min_Position_Limit: 0
     Max_Position_Limit: 4095
     Secondary_ID: 255
@@ -150,6 +160,7 @@ motors:
     Return_Delay_Time: 0
     Drive_Mode: 5
     Velocity_Limit: 131
+    Current_Limit: 0
     Min_Position_Limit: 910
     Max_Position_Limit: 3447
     Secondary_ID: 255
@@ -163,6 +174,7 @@ motors:
     Return_Delay_Time: 0
     Drive_Mode: 4
     Velocity_Limit: 131
+    Current_Limit: 0
     Min_Position_Limit: 0
     Max_Position_Limit: 4095
     Secondary_ID: 255
@@ -176,6 +188,7 @@ motors:
     Return_Delay_Time: 0
     Drive_Mode: 4
     Velocity_Limit: 131
+    Current_Limit: 0
     Min_Position_Limit: 0
     Max_Position_Limit: 4095
     Secondary_ID: 255

--- a/wx_armor/wx_armor/robot_profile.cc
+++ b/wx_armor/wx_armor/robot_profile.cc
@@ -17,11 +17,16 @@ bool convert<horizon::wx_armor::RobotProfile>::decode(
     float safety_vel_limit = info["Safety_Velocity_Limit"].as<float>();
     safety_vel_limit *= M_PI / 180.;
 
+    uint32_t current_limit = info["Current_Limit"].as<uint32_t>();
+
+    OpMode op_mode = (current_limit == 0) ? OpMode::POSITION : OpMode::CURRENT_BASED_POSITION;
+
     profile.motors.emplace_back(MotorInfo{
         .id = motor_id,
         .name = child.first.as<std::string>(),
         // By default, set the operation mode to position control.
-        .op_mode = OpMode::POSITION,
+        .op_mode = op_mode,
+        .current_limit = current_limit,
         .safety_vel_limit = safety_vel_limit
     });
 

--- a/wx_armor/wx_armor/robot_profile.h
+++ b/wx_armor/wx_armor/robot_profile.h
@@ -70,6 +70,10 @@ struct MotorInfo {
   // them here just to be consistent with dynamixel.
   OpMode op_mode = OpMode::POSITION;
 
+  // The current limit. If it is zero, the motor will be in OpMode::POSITION,
+  // otherwise, it will be in OpMode::CURRENT_BASED_POSITION.
+  uint32_t current_limit = 0;
+
   // The safety velocity limit in [rad/s]
   float safety_vel_limit = M_PI / 2;
 };

--- a/wx_armor/wx_armor/wx_armor_driver.h
+++ b/wx_armor/wx_armor/wx_armor_driver.h
@@ -137,15 +137,10 @@ class WxArmorDriver {
    * @param motor_config_path Filesystem path to the motor configuration file.
    * @param flash_eeprom Flag to indicate whether to flash the EEPROM on
    * construction.
-   * @param current_limit The maximum current (torque) that the motor can
-   * generate. It takes value between 0 and 1000. A value of 0 means no current
-   * limit, and a small non-zero current limit protects the robot from
-   * generating too much torque when there is a huge external force/torque.
    */
   WxArmorDriver(const std::string &usb_port,
                 std::filesystem::path motor_config_path,
-                bool flash_eeprom = false,
-                int32_t current_limit = 250);
+                bool flash_eeprom = false);
 
   ~WxArmorDriver();
 

--- a/wx_armor/wx_armor/wx_armor_ws.cc
+++ b/wx_armor/wx_armor/wx_armor_ws.cc
@@ -27,9 +27,8 @@ WxArmorDriver *Driver() {
                 .parent_path() /
             "configs" / "wx250s_motor_config.yaml");
     int flash_eeprom = true;
-    int current_limit = GetEnv<int>("WX_ARMOR_MOTOR_CURRENT_LIMIT", 0);
     return std::make_unique<WxArmorDriver>(
-        usb_port, motor_config, static_cast<bool>(flash_eeprom), current_limit);
+        usb_port, motor_config, static_cast<bool>(flash_eeprom));
   }();
   return driver.get();
 }


### PR DESCRIPTION
Remove the one scalar for all env variable logic for current based position control and added per motor config in the yaml file. Now we can have varying current limits / some motors operating in current-based position control while others are in normal position control.