### PR TITLE
higher joint vel limits as now we have delta limit in the driver

### DIFF
--- a/wx_armor/configs/wx250s_motor_config.yaml
+++ b/wx_armor/configs/wx250s_motor_config.yaml
@@ -82,7 +82,7 @@ motors:
     Secondary_ID: 255
     Position_P_Gain: 400
     Position_D_Gain: 3
-    Safety_Velocity_Limit: 380
+    Safety_Velocity_Limit: 500
 
   shoulder:
     ID: 2
@@ -96,7 +96,7 @@ motors:
     Secondary_ID: 255
     Position_P_Gain: 400
     Position_D_Gain: 3
-    Safety_Velocity_Limit: 380
+    Safety_Velocity_Limit: 1000
 
   shoulder_shadow:
     ID: 3
@@ -110,7 +110,7 @@ motors:
     Secondary_ID: 2
     Position_P_Gain: 400
     Position_D_Gain: 3
-    Safety_Velocity_Limit: 380
+    Safety_Velocity_Limit: 1000
 
   elbow:
     ID: 4
@@ -124,7 +124,7 @@ motors:
     Secondary_ID: 255
     Position_P_Gain: 400
     Position_D_Gain: 3
-    Safety_Velocity_Limit: 380
+    Safety_Velocity_Limit: 1000
 
   elbow_shadow:
     ID: 5
@@ -138,7 +138,7 @@ motors:
     Secondary_ID: 4
     Position_P_Gain: 400
     Position_D_Gain: 3
-    Safety_Velocity_Limit: 380
+    Safety_Velocity_Limit: 1000
 
   forearm_roll:
     ID: 6


### PR DESCRIPTION
This PR is to avoid over limit protection from triggering when arm is torqued off.

Because the limits are written into eeproms, there is no easy fix to only do the limit when torqued on.
This is still safe to do because we are using PID control with driver side delta limit.