### PR TITLE
Add a build script for wx_armor

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,27 +30,20 @@ make
 
 This package is known to build on Ubuntu 20.04. No other configuration or environment has been tested and is not supported, though it will probably work on other distributions of Ubuntu.
 
-#### Required Dependencies
-
-Building the packages requires the following dependencies:
-
-- cmake
-  - `sudo apt install -y cmake`
-- build-essential
-  - `sudo apt install -y build-essential`
-- [yaml-cpp-dev](https://launchpad.net/ubuntu/+source/yaml-cpp)
-  - `sudo apt install -y yaml-cpp-dev`
-
 #### Building From Source
 
+If building for the first time, run the following
 ```sh
 git clone --recursive https://github.com/HorizonRoboticsInternal/interbotix_xs_driver.git -b main
-cd interbotix_xs_driver/wx_armor
-mkdir build
-cd build
-cmake ..
-make
-sudo make install
+cd interbotix_xs_driver
+sudo ./build.sh --fresh
+```
+This should install all dependencies and build `wx_armor`.
+If simply trying to rebuild `wx_armor`, users can run `sudo ./build.sh` without `--fresh`.
+
+Users must also set `LD_LIBRARY_PATH` to the shared library locations. In your `~/.bashrc`, add the following line:
+```bash
+export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 ```
 
 ### Using ROS 2

--- a/README.md
+++ b/README.md
@@ -28,23 +28,30 @@ make
 
 ### Using Standalone C++ Library
 
-This package is known to build on Ubuntu 20.04. No other configuration or environment has been tested and is not supported, though it will probably work on other distributions of Ubuntu.
+This package is known to build on Ubuntu 22.04 and 24.04. 
+No other configuration or environments has been tested. Use at your own risk.
+It should work on other Ubuntu versions as well, so long as cmake is >= 3.23 (look at `build.sh` for details).
 
 #### Building From Source
 
-If building for the first time, run the following
+If building for the first time, first set the following in your .bashrc
+```bash
+export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+```
+Then, run the following
 ```sh
-git clone --recursive https://github.com/HorizonRoboticsInternal/interbotix_xs_driver.git -b main
+git clone --recursive git@github.com:HorizonRoboticsInternal/interbotix_xs_driver.git -b main
 cd interbotix_xs_driver
 sudo ./build.sh --fresh
 ```
 This should install all dependencies and build `wx_armor`.
 If simply trying to rebuild `wx_armor`, users can run `sudo ./build.sh` without `--fresh`.
 
-Users must also set `LD_LIBRARY_PATH` to the shared library locations. In your `~/.bashrc`, add the following line:
-```bash
-export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
-```
+Note that current build requires cmake >= 3.23, which will automatically be handled for Ubuntu 22.04 users.
+For Ubuntu 24.04, cmake should already satisfy this requirement.
+
+
+Users can find instructions for installing on Jetson devices [here](https://github.com/HorizonRoboticsInternal/robot-system-config/tree/main/jetson).
 
 ### Using ROS 2
 

--- a/README.md
+++ b/README.md
@@ -28,17 +28,13 @@ make
 
 ### Using Standalone C++ Library
 
-This package is known to build on Ubuntu 22.04 and 24.04. 
+This package is known to build on Ubuntu 22.04 and 24.04.
 No other configuration or environments has been tested. Use at your own risk.
 It should work on other Ubuntu versions as well, so long as cmake is >= 3.23 (look at `build.sh` for details).
 
 #### Building From Source
 
-If building for the first time, first set the following in your .bashrc
-```bash
-export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
-```
-Then, run the following
+If building for the first time, simply run the following
 ```sh
 git clone --recursive git@github.com:HorizonRoboticsInternal/interbotix_xs_driver.git -b main
 cd interbotix_xs_driver

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+set -e  # Exit immediately if a command exits with a non-zero status
+
+HOME_DIR=$(pwd)
+
+# Parse flags
+FRESH_INSTALL=false
+
+# Check for the --fresh flag
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --fresh) FRESH_INSTALL=true ;;
+        *) echo "Unknown parameter: $1"; exit 1 ;;
+    esac
+    shift
+done
+
+# Function to build a project
+build_project() {
+    local project_dir=$1
+    cd "$project_dir"
+
+    if [ "$FRESH_INSTALL" = true ]; then
+        rm -rf build
+    fi
+
+    mkdir -p build
+    cd build
+    cmake ..
+    make -j"$(nproc)"
+    make install
+    cd "$HOME_DIR"
+}
+
+
+if [ "$FRESH_INSTALL" = true ]; then
+    apt install -y cmake
+    apt install -y build-essential
+    apt install -y libyaml-cpp-dev
+    apt install libjsoncpp-dev
+    apt install uuid-dev
+
+
+    # Update cmake to version >= 3.23 for Ubuntu 22.04
+    # For other repos, refer to
+    # https://askubuntu.com/questions/355565/how-do-i-install-the-latest-version-of-cmake-from-the-command-line#:~:text=Kitware%20now%20has%20an%20APT%20repository%20that%20currently%20supports%2020.04%2C%2022.04%20and%2024.04.
+    # Get the installed version of CMake
+    CMAKE_VERSION=$(cmake --version | head -n 1 | awk '{print $3}')
+    # Compare the version to 3.23
+    if [ "$(printf '%s\n' "$CMAKE_VERSION" "3.23" | sort -V | head -n 1)" != "3.23" ]; then
+        echo "CMake version is less than 3.23 (current: $CMAKE_VERSION). Updating..."
+        # Update CMake
+        apt purge --auto-remove cmake
+        wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+        echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null
+        apt update
+        apt install cmake
+    else
+        echo "CMake version is 3.23 or newer (current: $CMAKE_VERSION). No update needed."
+    fi
+
+    # Install json
+    cd /tmp
+    rm -rf json
+    git clone https://github.com/nlohmann/json
+    cd json
+    mkdir build
+    cd build
+    cmake ..
+    make -j"$(nproc)"
+    make install
+    cd /tmp
+    rm -rf json
+    cd "$HOME_DIR"
+
+    # Install drogon
+    cd /tmp
+    rm -rf drogon
+    git clone https://github.com/drogonframework/drogon
+    cd drogon
+    git submodule update --init
+    mkdir build
+    cd build
+    cmake ..
+    make -j"$(nproc)"
+    make install
+    cd /tmp
+    rm -rf drogon
+    cd "$HOME_DIR"
+
+    # Install spdlog
+    cd /tmp
+    rm -rf spdlog
+    git clone https://github.com/gabime/spdlog.git
+    cd spdlog
+    mkdir build
+    cd build
+    cmake -DSPDLOG_BUILD_SHARED=on ..
+    make -j"$(nproc)"
+    make install
+    cd /tmp
+    rm -rf spdlog
+    cd "$HOME_DIR"
+
+    # Build dynamixel_sdk
+    build_project "third_party_libraries/DynamixelSDK"
+
+    # Build dynamixel_workbench
+    build_project "third_party_libraries/dynamixel-workbench"
+fi
+
+# Build wx_armor
+build_project "wx_armor"

--- a/build.sh
+++ b/build.sh
@@ -43,6 +43,7 @@ if [ "$FRESH_INSTALL" = true ]; then
 
 
     # Update cmake to version >= 3.23 for Ubuntu 22.04
+    # This should be satisfied for Ubuntu 24.04
     # For other repos, refer to
     # https://askubuntu.com/questions/355565/how-do-i-install-the-latest-version-of-cmake-from-the-command-line#:~:text=Kitware%20now%20has%20an%20APT%20repository%20that%20currently%20supports%2020.04%2C%2022.04%20and%2024.04.
     # Get the installed version of CMake

--- a/wx_armor/CMakeLists.txt
+++ b/wx_armor/CMakeLists.txt
@@ -11,6 +11,12 @@ project(wx_armor
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Add /usr/local to search path for dependencies
+list(APPEND CMAKE_PREFIX_PATH "/usr/local")
+set(CMAKE_INSTALL_RPATH "/usr/local/lib")
+set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
+
+
 include(CMakeDependentOption)
 include(GNUInstallDirs)
 include(InstallRequiredSystemLibraries)
@@ -40,7 +46,7 @@ target_sources(robot_profile
     PRIVATE wx_armor/robot_profile.cc)
 target_link_libraries(robot_profile PUBLIC
     spdlog::spdlog
-    yaml-cpp)
+    yaml-cpp::yaml-cpp)
 
 add_library(wx_armor_driver STATIC)
 target_sources(wx_armor_driver
@@ -54,7 +60,7 @@ target_link_libraries(wx_armor_driver PUBLIC
     dynamixel_workbench_toolbox
     spdlog::spdlog
     nlohmann_json::nlohmann_json
-    yaml-cpp)
+    yaml-cpp::yaml-cpp)
 
 add_library(guardian_thread STATIC)
 target_sources(guardian_thread


### PR DESCRIPTION
This PR adds an automated build script for `wx_armor`. It's quite annoying / tedious to have to install it on fresh machines. This script should now handle all necessary dependencies seamlessly.

Tested on two separate machines.

An old tutorial can be found here for reference.
https://horizonrobotics.feishu.cn/wiki/NYL6wgBc8i05O0kLkk2cqFNxn2g