### PR TITLE
Add precommit and update clang-format. Change indent width to 4.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,28 +1,55 @@
-# This file is used by clang-format to autoformat SocialBot source code
-#
-# The clang-format is part of llvm toolchain.
-# It need to install llvm and clang to format source code style.
-#
-# The basic usage is,
-#   clang-format -i -style=file PATH/TO/SOURCE/CODE
-#
-# The -style=file implicit use ".clang-format" file located in one of
-# parent directory.
-# The -i means inplace change.
-#
-# The document of clang-format is
-#   http://clang.llvm.org/docs/ClangFormat.html
-#   http://clang.llvm.org/docs/ClangFormatStyleOptions.html
----
-Language:        Cpp
-BasedOnStyle:  Google
-IndentWidth:     2
-TabWidth:        2
+AlignAfterOpenBracket: Align
+AlignOperands: Align
+AllowShortBlocksOnASingleLine: Never
+AllowShortEnumsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterControlStatement: Never
+  AfterClass: true
+  AfterFunction: false
+  AfterNamespace: true
+  AfterStruct: true
+  AfterUnion: true
+  BeforeCatch: true
+  BeforeElse: true
+  BeforeWhile: false
+  IndentBraces: false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakBeforeBinaryOperators: None
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: AfterComma
+BreakStringLiterals: true
+BreakTemplateDeclarations: Yes
+ColumnLimit: 100
 ContinuationIndentWidth: 4
-AccessModifierOffset: -1  # The private/protected/public has no indent in class
-Standard:  Cpp11
-AllowAllParametersOfDeclarationOnNextLine: true
-BinPackParameters: false
-BinPackArguments: false
-SortIncludes: true
-...
+IndentWidth: 4
+IndentCaseLabels: true
+IncludeBlocks: Preserve
+QualifierAlignment: Left
+ReferenceAlignment: Left
+ReflowComments: true
+PointerAlignment: Left
+RemoveParentheses: MultipleParentheses
+SeparateDefinitionBlocks: Always
+SortUsingDeclarations: LexicographicNumeric
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpacesBeforeTrailingComments: 2
+SpacesInLineCommentPrefix:
+  Minimum: 1
+  Maximum: -1
+Standard: Latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v19.1.3
+    hooks:
+      - id: clang-format
+        args: ["--style=file"]

--- a/include/interbotix_xs_driver/xs_common.hpp
+++ b/include/interbotix_xs_driver/xs_common.hpp
@@ -29,13 +29,13 @@
 #ifndef INTERBOTIX_XS_DRIVER__XS_COMMON_HPP_
 #define INTERBOTIX_XS_DRIVER__XS_COMMON_HPP_
 
-#include "interbotix_xs_driver/xs_logging.hpp"
-
 #include <chrono>
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
+
+#include "interbotix_xs_driver/xs_logging.hpp"
 
 namespace interbotix_xs
 {
@@ -67,12 +67,12 @@ inline static const std::string DEFAULT_OP_MODE = "position";
 // Default motor profile type is 'velocity' (as opposed to 'time')
 inline static const std::string DEFAULT_PROF_TYPE = "velocity";
 
-// Allow joint velocity to be infinite when in position control mode - makes robot very reactive to
-// joint commands
+// Allow joint velocity to be infinite when in position control mode - makes
+// robot very reactive to joint commands
 static const int32_t DEFAULT_PROF_VEL = 0;
 
-// Allow joint acceleration to be infinite when in position control mode - makes robot very
-// reactive to joint commands
+// Allow joint acceleration to be infinite when in position control mode - makes
+// robot very reactive to joint commands
 static const int32_t DEFAULT_PROF_ACC = 0;
 
 // Torque motor on by default
@@ -111,67 +111,67 @@ namespace profile
 inline static const std::string VELOCITY = "velocity";
 inline static const std::string TIME = "time";
 
-}  // profile
-
+}  // namespace profile
 
 // Struct to hold multiple joints that represent a group
 struct JointGroup
 {
-  // Names of all joints in the group
-  std::vector<std::string> joint_names;
-  // Dynamixel ID of all joints in the group
-  std::vector<uint8_t> joint_ids;
-  // Number of joints in the group
-  uint8_t joint_num;
-  // Operating Mode for all joints in the group
-  std::string mode;
-  // Profile Type ('velocity' or 'time') for all joints in the group
-  std::string profile_type;
-  // Profile Velocity (in ms) for all joints in the group
-  int32_t profile_velocity;
-  // Profile Acceleration (in ms) for all joints in the group
-  int32_t profile_acceleration;
+    // Names of all joints in the group
+    std::vector<std::string> joint_names;
+    // Dynamixel ID of all joints in the group
+    std::vector<uint8_t> joint_ids;
+    // Number of joints in the group
+    uint8_t joint_num;
+    // Operating Mode for all joints in the group
+    std::string mode;
+    // Profile Type ('velocity' or 'time') for all joints in the group
+    std::string profile_type;
+    // Profile Velocity (in ms) for all joints in the group
+    int32_t profile_velocity;
+    // Profile Acceleration (in ms) for all joints in the group
+    int32_t profile_acceleration;
 };
 
 // Struct to hold data on a single motor
 struct MotorState
 {
-  // Dynamixel ID of the motor
-  uint8_t motor_id;
-  // Operating Mode of the motor
-  std::string mode;
-  // Profile Type ('velocity' or 'time') for the motor
-  std::string profile_type;
-  // Profile Velocity (in ms) for the motor
-  int32_t profile_velocity;
-  // Profile Acceleration (in ms) for the motor
-  int32_t profile_acceleration;
+    // Dynamixel ID of the motor
+    uint8_t motor_id;
+    // Operating Mode of the motor
+    std::string mode;
+    // Profile Type ('velocity' or 'time') for the motor
+    std::string profile_type;
+    // Profile Velocity (in ms) for the motor
+    int32_t profile_velocity;
+    // Profile Acceleration (in ms) for the motor
+    int32_t profile_acceleration;
 };
 
 // Struct to hold data on an Interbotix Gripper
 struct Gripper
 {
-  // Index in the published JointState message 'name' list belonging to the gripper motor
-  size_t js_index;
-  // Distance [m] from the motor horn's center to its edge
-  float horn_radius;
-  // Distance [m] from the edge of the motor horn to a finger
-  float arm_length;
-  // Name of the 'left_finger' joint as defined in the URDF (if present)
-  std::string left_finger;
-  // Name of the 'right_finger' joint as defined in the URDF (if present)
-  std::string right_finger;
+    // Index in the published JointState message 'name' list belonging to the
+    // gripper motor
+    size_t js_index;
+    // Distance [m] from the motor horn's center to its edge
+    float horn_radius;
+    // Distance [m] from the edge of the motor horn to a finger
+    float arm_length;
+    // Name of the 'left_finger' joint as defined in the URDF (if present)
+    std::string left_finger;
+    // Name of the 'right_finger' joint as defined in the URDF (if present)
+    std::string right_finger;
 };
 
 // Struct to hold a desired register value for a given motor
 struct MotorRegVal
 {
-  // Dynamixel ID of a motor
-  uint8_t motor_id;
-  // Register name
-  std::string reg;
-  // Value to write to the above register for the specified motor
-  int32_t value;
+    // Dynamixel ID of a motor
+    uint8_t motor_id;
+    // Register name
+    std::string reg;
+    // Value to write to the above register for the specified motor
+    int32_t value;
 };
 
 using MapGroup = std::unordered_map<std::string, JointGroup>;

--- a/include/interbotix_xs_driver/xs_driver.hpp
+++ b/include/interbotix_xs_driver/xs_driver.hpp
@@ -29,23 +29,22 @@
 #ifndef INTERBOTIX_XS_DRIVER__XS_DRIVER_HPP_
 #define INTERBOTIX_XS_DRIVER__XS_DRIVER_HPP_
 
+#include <math.h>
+
+#include <algorithm>
+#include <bitset>
+#include <chrono>
 #include <interbotix_xs_driver/version.hpp>
 #include <interbotix_xs_driver/xs_common.hpp>
 #include <interbotix_xs_driver/xs_logging.hpp>
-
-#include <math.h>
-
-#include <chrono>
-#include <string>
-#include <bitset>
-#include <vector>
-#include <algorithm>
 #include <memory>
 #include <mutex>
+#include <string>
 #include <unordered_map>
+#include <vector>
 
-#include "yaml-cpp/yaml.h"
 #include "dynamixel_workbench_toolbox/dynamixel_workbench.h"
+#include "yaml-cpp/yaml.h"
 
 namespace interbotix_xs
 {
@@ -53,383 +52,397 @@ namespace interbotix_xs
 // Interbotix Core Class to build any type of DYNAMIXEL-based robot
 class InterbotixDriverXS
 {
-public:
-  /// @brief Constructor for the InterbotixDriverXS
-  /// @param filepath_motor_configs absolute filepah to the motor configuration file
-  /// @param filepath_mode_configs absolute filepah to the modes configuration file
-  /// @param write_eeprom_on_startup whether or not to write configs to EEPROM on startup,
-  ///   defaults to `true`
-  /// @param logging_level the logging level of the xs_logging utility; defaults to "INFO"
-  /// @throws runtime_error if constructor was not initialized properly due to bad configuration
-  ///   file, inability to open specified serial port, inability to ping all specified motors, or
-  ///   inability to write startup configuration to all motors' EEPROMs
-  explicit InterbotixDriverXS(
-    std::string filepath_motor_configs,
-    std::string filepath_mode_configs,
-    bool write_eeprom_on_startup = true,
-    std::string logging_level = "INFO");
+  public:
+    /// @brief Constructor for the InterbotixDriverXS
+    /// @param filepath_motor_configs absolute filepah to the motor
+    /// configuration file
+    /// @param filepath_mode_configs absolute filepah to the modes configuration
+    /// file
+    /// @param write_eeprom_on_startup whether or not to write configs to EEPROM
+    /// on startup,
+    ///   defaults to `true`
+    /// @param logging_level the logging level of the xs_logging utility;
+    /// defaults to "INFO"
+    /// @throws runtime_error if constructor was not initialized properly due to
+    /// bad configuration
+    ///   file, inability to open specified serial port, inability to ping all
+    ///   specified motors, or inability to write startup configuration to all
+    ///   motors' EEPROMs
+    explicit InterbotixDriverXS(std::string filepath_motor_configs,
+                                std::string filepath_mode_configs,
+                                bool write_eeprom_on_startup = true,
+                                std::string logging_level = "INFO");
 
-  /// @brief Destructor for the InterbotixDriverXS
-  ~InterbotixDriverXS() {}
+    /// @brief Destructor for the InterbotixDriverXS
+    ~InterbotixDriverXS() {
+    }
 
-  /// @brief Set the operating mode for a specific group of motors or a single motor
-  /// @param cmd_type set to 'CMD_TYPE_GROUP' if changing the operating mode for a group of motors
-  ///   or 'CMD_TYPE_SINGLE' if changing the operating mode for a single motor
-  /// @param name desired motor group name if cmd_type is set to 'CMD_TYPE_GROUP' or the desired
-  ///   motor name if cmd_type is set to 'CMD_TYPE_SINGLE'
-  /// @param mode desired operating mode (either 'position', 'linear_position', 'ext_position',
-  ///   'velocity', 'pwm', 'current', or 'current_based_position')
-  /// @param profile_type set to 'velocity' for a Velocity-based Profile or 'time' for a Time-based
-  ///   Profile (modifies Bit 2 of the 'Drive_Mode' register)
-  /// @param profile_velocity passthrough to the Profile_Velocity register on the motor
-  /// @param profile_acceleration passthrough to the Profile_Acceleration register on the motor
-  bool set_operating_modes(
-    const std::string & cmd_type,
-    const std::string & name,
-    const std::string & mode,
-    const std::string profile_type = DEFAULT_PROF_TYPE,
-    const int32_t profile_velocity = DEFAULT_PROF_VEL,
-    const int32_t profile_acceleration = DEFAULT_PROF_ACC);
+    /// @brief Set the operating mode for a specific group of motors or a single
+    /// motor
+    /// @param cmd_type set to 'CMD_TYPE_GROUP' if changing the operating mode
+    /// for a group of motors
+    ///   or 'CMD_TYPE_SINGLE' if changing the operating mode for a single motor
+    /// @param name desired motor group name if cmd_type is set to
+    /// 'CMD_TYPE_GROUP' or the desired
+    ///   motor name if cmd_type is set to 'CMD_TYPE_SINGLE'
+    /// @param mode desired operating mode (either 'position',
+    /// 'linear_position', 'ext_position',
+    ///   'velocity', 'pwm', 'current', or 'current_based_position')
+    /// @param profile_type set to 'velocity' for a Velocity-based Profile or
+    /// 'time' for a Time-based
+    ///   Profile (modifies Bit 2 of the 'Drive_Mode' register)
+    /// @param profile_velocity passthrough to the Profile_Velocity register on
+    /// the motor
+    /// @param profile_acceleration passthrough to the Profile_Acceleration
+    /// register on the motor
+    bool set_operating_modes(const std::string& cmd_type, const std::string& name,
+                             const std::string& mode,
+                             const std::string profile_type = DEFAULT_PROF_TYPE,
+                             const int32_t profile_velocity = DEFAULT_PROF_VEL,
+                             const int32_t profile_acceleration = DEFAULT_PROF_ACC);
 
-  /// @brief Set the operating mode for a single motor
-  /// @param name desired motor name
-  /// @param mode desired operating mode (either 'position', 'linear_position', 'ext_position',
-  ///   'velocity', 'pwm', 'current', or 'current_based_position')
-  /// @param profile_type set to 'velocity' for a Velocity-based Profile or 'time' for a Time-based
-  ///   Profile (modifies Bit 2 of the 'Drive_Mode' register)
-  /// @param profile_velocity passthrough to the Profile_Velocity register on the motor
-  /// @param profile_acceleration passthrough to the Profile_Acceleration register on the motor
-  bool set_joint_operating_mode(
-    const std::string & name,
-    const std::string & mode,
-    const std::string profile_type = DEFAULT_PROF_TYPE,
-    const int32_t profile_velocity = DEFAULT_PROF_VEL,
-    const int32_t profile_acceleration = DEFAULT_PROF_ACC);
+    /// @brief Set the operating mode for a single motor
+    /// @param name desired motor name
+    /// @param mode desired operating mode (either 'position',
+    /// 'linear_position', 'ext_position',
+    ///   'velocity', 'pwm', 'current', or 'current_based_position')
+    /// @param profile_type set to 'velocity' for a Velocity-based Profile or
+    /// 'time' for a Time-based
+    ///   Profile (modifies Bit 2 of the 'Drive_Mode' register)
+    /// @param profile_velocity passthrough to the Profile_Velocity register on
+    /// the motor
+    /// @param profile_acceleration passthrough to the Profile_Acceleration
+    /// register on the motor
+    bool set_joint_operating_mode(const std::string& name, const std::string& mode,
+                                  const std::string profile_type = DEFAULT_PROF_TYPE,
+                                  const int32_t profile_velocity = DEFAULT_PROF_VEL,
+                                  const int32_t profile_acceleration = DEFAULT_PROF_ACC);
 
-  /// @brief Torque On/Off a specific group of motors or a single motor
-  /// @param cmd_type set to 'CMD_TYPE_GROUP' if torquing off a group of motors or
-  ///   'CMD_TYPE_SINGLE' if torquing off a single motor
-  /// @param name desired motor group name if cmd_type is set to 'CMD_TYPE_GROUP' or the desired
-  ///   motor name if cmd_type is set to 'CMD_TYPE_SINGLE'
-  /// @param enable set to True to torque on or False to torque off
-  bool torque_enable(
-    const std::string cmd_type,
-    const std::string & name,
-    const bool & enable);
+    /// @brief Torque On/Off a specific group of motors or a single motor
+    /// @param cmd_type set to 'CMD_TYPE_GROUP' if torquing off a group of
+    /// motors or
+    ///   'CMD_TYPE_SINGLE' if torquing off a single motor
+    /// @param name desired motor group name if cmd_type is set to
+    /// 'CMD_TYPE_GROUP' or the desired
+    ///   motor name if cmd_type is set to 'CMD_TYPE_SINGLE'
+    /// @param enable set to True to torque on or False to torque off
+    bool torque_enable(const std::string cmd_type, const std::string& name, const bool& enable);
 
-  /// @brief Reboot a specific group of motors or a single motor
-  /// @param cmd_type set to 'CMD_TYPE_GROUP' if rebooting a group of motors or 'CMD_TYPE_SINGLE'
-  ///   if rebooting a single motor
-  /// @param name desired motor group name if cmd_type is set to 'CMD_TYPE_GROUP' or the desired
-  ///   motor name if cmd_type is set to 'CMD_TYPE_SINGLE'
-  /// @param torque_enable set to True to torque on or False to torque off after rebooting
-  /// @param smart_reboot set to True to only reboot motor(s) in a specified group that have gone
-  ///   into an error state
-  bool reboot_motors(
-    const std::string cmd_type,
-    const std::string & name,
-    const bool & enable,
-    const bool & smart_reboot);
+    /// @brief Reboot a specific group of motors or a single motor
+    /// @param cmd_type set to 'CMD_TYPE_GROUP' if rebooting a group of motors
+    /// or 'CMD_TYPE_SINGLE'
+    ///   if rebooting a single motor
+    /// @param name desired motor group name if cmd_type is set to
+    /// 'CMD_TYPE_GROUP' or the desired
+    ///   motor name if cmd_type is set to 'CMD_TYPE_SINGLE'
+    /// @param torque_enable set to True to torque on or False to torque off
+    /// after rebooting
+    /// @param smart_reboot set to True to only reboot motor(s) in a specified
+    /// group that have gone
+    ///   into an error state
+    bool reboot_motors(const std::string cmd_type, const std::string& name, const bool& enable,
+                       const bool& smart_reboot);
 
-  /// @brief Command a desired group of motors with the specified commands
-  /// @param name desired motor group name
-  /// @param commands vector of commands (order matches the order specified in the 'groups'
-  ///   section in the motor config file)
-  /// @details commands are processed differently based on the operating mode specified for the
-  ///   motor group
-  template<typename T>
-  bool write_commands(
-    const std::string & name,
-    std::vector<T> commands);
+    /// @brief Command a desired group of motors with the specified commands
+    /// @param name desired motor group name
+    /// @param commands vector of commands (order matches the order specified in
+    /// the 'groups'
+    ///   section in the motor config file)
+    /// @details commands are processed differently based on the operating mode
+    /// specified for the
+    ///   motor group
+    template <typename T>
+    bool write_commands(const std::string& name, std::vector<T> commands);
 
-  /// @brief Command a desired group of motors with the specified position commands
-  /// @param name desired motor group name
-  /// @param commands vector of commands (order matches the order specified in the 'groups'
-  ///   section in the motor config file)
-  /// @param blocking whether the function should wait to return control to the user until the
-  ///   robot finishes moving; set to false by default
-  /// @details will not perform movement if desired group is not in position mode
-  bool write_position_commands(
-    const std::string & name,
-    std::vector<float> commands,
-    bool blocking = false);
+    /// @brief Command a desired group of motors with the specified position
+    /// commands
+    /// @param name desired motor group name
+    /// @param commands vector of commands (order matches the order specified in
+    /// the 'groups'
+    ///   section in the motor config file)
+    /// @param blocking whether the function should wait to return control to
+    /// the user until the
+    ///   robot finishes moving; set to false by default
+    /// @details will not perform movement if desired group is not in position
+    /// mode
+    bool write_position_commands(const std::string& name, std::vector<float> commands,
+                                 bool blocking = false);
 
-  /// @brief Command a desired motor with the specified command
-  /// @param name desired motor name
-  /// @param command motor command
-  /// @details the command is processed differently based on the operating mode specified for the
-  ///   motor
-  bool write_joint_command(
-    const std::string & name,
-    float command);
+    /// @brief Command a desired motor with the specified command
+    /// @param name desired motor name
+    /// @param command motor command
+    /// @details the command is processed differently based on the operating
+    /// mode specified for the
+    ///   motor
+    bool write_joint_command(const std::string& name, float command);
 
-  /// @brief Set motor firmware PID gains
-  /// @param cmd_type set to 'CMD_TYPE_GROUP' if changing the PID gains for a group of motors or
-  ///   'CMD_TYPE_SINGLE' if changing the PID gains for a single motor
-  /// @param name desired motor group name if cmd_type is set to 'CMD_TYPE_GROUP' or the desired
-  ///   motor name if cmd_type is set to 'CMD_TYPE_SINGLE'
-  /// @param gains vector containing the desired PID gains - order is as shown in the function
-  bool set_motor_pid_gains(
-    const std::string cmd_type,
-    const std::string & name,
-    const std::vector<int32_t> & gains);
+    /// @brief Set motor firmware PID gains
+    /// @param cmd_type set to 'CMD_TYPE_GROUP' if changing the PID gains for a
+    /// group of motors or
+    ///   'CMD_TYPE_SINGLE' if changing the PID gains for a single motor
+    /// @param name desired motor group name if cmd_type is set to
+    /// 'CMD_TYPE_GROUP' or the desired
+    ///   motor name if cmd_type is set to 'CMD_TYPE_SINGLE'
+    /// @param gains vector containing the desired PID gains - order is as shown
+    /// in the function
+    bool set_motor_pid_gains(const std::string cmd_type, const std::string& name,
+                             const std::vector<int32_t>& gains);
 
-  /// @brief Set a register value to multiple motors
-  /// @param cmd_type set to 'CMD_TYPE_GROUP' if setting register values for a group of motors or
-  ///   'CMD_TYPE_SINGLE' if setting a single register value
-  /// @param name desired motor group name if cmd_type is set to 'CMD_TYPE_GROUP' or the desired
-  ///   motor name if cmd_type is set to 'CMD_TYPE_SINGLE'
-  /// @param reg the register to set
-  /// @param value desired register value
-  bool set_motor_registers(
-    const std::string cmd_type,
-    const std::string & name,
-    const std::string & reg,
-    const int32_t & value);
+    /// @brief Set a register value to multiple motors
+    /// @param cmd_type set to 'CMD_TYPE_GROUP' if setting register values for a
+    /// group of motors or
+    ///   'CMD_TYPE_SINGLE' if setting a single register value
+    /// @param name desired motor group name if cmd_type is set to
+    /// 'CMD_TYPE_GROUP' or the desired
+    ///   motor name if cmd_type is set to 'CMD_TYPE_SINGLE'
+    /// @param reg the register to set
+    /// @param value desired register value
+    bool set_motor_registers(const std::string cmd_type, const std::string& name,
+                             const std::string& reg, const int32_t& value);
 
-  /// @brief Get a register value from multiple motors
-  /// @param cmd_type set to 'CMD_TYPE_GROUP' if getting register values from a group of motors or
-  ///   'CMD_TYPE_SINGLE' if getting a single register value
-  /// @param name desired motor group name if cmd_type is set to 'CMD_TYPE_GROUP' or the desired
-  ///   motor name if cmd_type is set to 'CMD_TYPE_SINGLE'
-  /// @param reg the register to get
-  /// @param values [out] vector of register values
-  bool get_motor_registers(
-    const std::string cmd_type,
-    const std::string & name,
-    const std::string & reg,
-    std::vector<int32_t> & values);
+    /// @brief Get a register value from multiple motors
+    /// @param cmd_type set to 'CMD_TYPE_GROUP' if getting register values from
+    /// a group of motors or
+    ///   'CMD_TYPE_SINGLE' if getting a single register value
+    /// @param name desired motor group name if cmd_type is set to
+    /// 'CMD_TYPE_GROUP' or the desired
+    ///   motor name if cmd_type is set to 'CMD_TYPE_SINGLE'
+    /// @param reg the register to get
+    /// @param values [out] vector of register values
+    bool get_motor_registers(const std::string cmd_type, const std::string& name,
+                             const std::string& reg, std::vector<int32_t>& values);
 
-  /// @brief Get states for a group of joints
-  /// @param name desired joint group name
-  /// @param positions [out] vector of current joint positions [rad]
-  /// @param velocities [out] vector of current joint velocities [rad/s]
-  /// @param effort [out] vector of current joint effort [mA]
-  bool get_joint_states(
-    const std::string & name = "all",
-    std::vector<float> * positions = NULL,
-    std::vector<float> * velocities = NULL,
-    std::vector<float> * effort = NULL);
+    /// @brief Get states for a group of joints
+    /// @param name desired joint group name
+    /// @param positions [out] vector of current joint positions [rad]
+    /// @param velocities [out] vector of current joint velocities [rad/s]
+    /// @param effort [out] vector of current joint effort [mA]
+    bool get_joint_states(const std::string& name = "all", std::vector<float>* positions = NULL,
+                          std::vector<float>* velocities = NULL, std::vector<float>* effort = NULL);
 
-  /// @brief Get states for a group of joints
-  /// @param name desired joint group name
-  /// @param positions [out] vector of current joint positions [rad]
-  /// @param velocities [out] vector of current joint velocities [rad/s]
-  /// @param effort [out] vector of current joint effort [mA]
-  bool get_joint_states(
-    const std::string & name = "all",
-    std::vector<double> * positions = NULL,
-    std::vector<double> * velocities = NULL,
-    std::vector<double> * effort = NULL);
+    /// @brief Get states for a group of joints
+    /// @param name desired joint group name
+    /// @param positions [out] vector of current joint positions [rad]
+    /// @param velocities [out] vector of current joint velocities [rad/s]
+    /// @param effort [out] vector of current joint effort [mA]
+    bool get_joint_states(const std::string& name = "all", std::vector<double>* positions = NULL,
+                          std::vector<double>* velocities = NULL,
+                          std::vector<double>* effort = NULL);
 
-  /// @brief Get states for a single joint
-  /// @param name desired joint name
-  /// @param position [out] current joint position [rad]
-  /// @param velocity [out] current joint velocity [rad/s]
-  /// @param effort [out] current joint effort [mA]
-  bool get_joint_state(
-    const std::string & name,
-    float * position = NULL,
-    float * velocity = NULL,
-    float * effort = NULL);
+    /// @brief Get states for a single joint
+    /// @param name desired joint name
+    /// @param position [out] current joint position [rad]
+    /// @param velocity [out] current joint velocity [rad/s]
+    /// @param effort [out] current joint effort [mA]
+    bool get_joint_state(const std::string& name, float* position = NULL, float* velocity = NULL,
+                         float* effort = NULL);
 
-  /// @brief Get states for a single joint
-  /// @param name desired joint name
-  /// @param position [out] current joint position [rad]
-  /// @param velocity [out] current joint velocity [rad/s]
-  /// @param effort [out] current joint effort [mA]
-  bool get_joint_state(
-    const std::string & name,
-    double * position = NULL,
-    double * velocity = NULL,
-    double * effort = NULL);
+    /// @brief Get states for a single joint
+    /// @param name desired joint name
+    /// @param position [out] current joint position [rad]
+    /// @param velocity [out] current joint velocity [rad/s]
+    /// @param effort [out] current joint effort [mA]
+    bool get_joint_state(const std::string& name, double* position = NULL, double* velocity = NULL,
+                         double* effort = NULL);
 
-  /// @brief Convert linear distance between two gripper fingers into angular position
-  /// @param name name of the gripper servo to command
-  /// @param linear_position desired distance [m] between the two gripper fingers
-  /// @returns angular position [rad] that achieves the desired linear distance
-  float convert_linear_position_to_radian(
-    const std::string & name,
-    const float & linear_position);
+    /// @brief Convert linear distance between two gripper fingers into angular
+    /// position
+    /// @param name name of the gripper servo to command
+    /// @param linear_position desired distance [m] between the two gripper
+    /// fingers
+    /// @returns angular position [rad] that achieves the desired linear
+    /// distance
+    float convert_linear_position_to_radian(const std::string& name, const float& linear_position);
 
-  /// @brief Convert angular position into the linear distance from one gripper finger to the
-  ///   center of the gripper servo horn
-  /// @param name name of the gripper sevo to command
-  /// @param angular_position desired gripper angular position [rad]
-  /// @returns linear position [m] from a gripper finger to the center of the gripper servo horn
-  float convert_angular_position_to_linear(
-    const std::string & name,
-    const float & angular_position);
+    /// @brief Convert angular position into the linear distance from one
+    /// gripper finger to the
+    ///   center of the gripper servo horn
+    /// @param name name of the gripper sevo to command
+    /// @param angular_position desired gripper angular position [rad]
+    /// @returns linear position [m] from a gripper finger to the center of the
+    /// gripper servo horn
+    float convert_angular_position_to_linear(const std::string& name,
+                                             const float& angular_position);
 
-  /// @brief Get a vector of all joint names in the all_ptr JointGroup
-  std::vector<std::string> get_all_joint_names();
+    /// @brief Get a vector of all joint names in the all_ptr JointGroup
+    std::vector<std::string> get_all_joint_names();
 
-  /// @brief Get the sleep position of a given joint
-  /// @param name the name of the joint to get the sleep position of
-  /// @returns the sleep position of the given joint
-  float get_joint_sleep_position(const std::string & name);
+    /// @brief Get the sleep position of a given joint
+    /// @param name the name of the joint to get the sleep position of
+    /// @returns the sleep position of the given joint
+    float get_joint_sleep_position(const std::string& name);
 
-  /// @brief Get the group map
-  /// @returns pointer to the group map
-  std::unordered_map<std::string, JointGroup> * get_group_map();
+    /// @brief Get the group map
+    /// @returns pointer to the group map
+    std::unordered_map<std::string, JointGroup>* get_group_map();
 
-  /// @brief Get the motor map
-  /// @returns pointer to the motor map
-  std::unordered_map<std::string, MotorState> * get_motor_map();
+    /// @brief Get the motor map
+    /// @returns pointer to the motor map
+    std::unordered_map<std::string, MotorState>* get_motor_map();
 
-  /// @brief Get info on the given joint group
-  /// @param name name of the joint group to get info on
-  /// @returns pointer to JointGroup
-  JointGroup * get_group_info(const std::string & name);
+    /// @brief Get info on the given joint group
+    /// @param name name of the joint group to get info on
+    /// @returns pointer to JointGroup
+    JointGroup* get_group_info(const std::string& name);
 
-  /// @brief Get MotorState of given joint
-  /// @param name name of the joint to get motor info on
-  /// @returns pointer to MotorState
-  MotorState * get_motor_info(const std::string & name);
+    /// @brief Get MotorState of given joint
+    /// @param name name of the joint to get motor info on
+    /// @returns pointer to MotorState
+    MotorState* get_motor_info(const std::string& name);
 
-  /// @brief Get MotorState of given gripper
-  /// @param name name of the gripper to get info on
-  /// @returns pointer to Gripper
-  Gripper * get_gripper_info(const std::string & name);
+    /// @brief Get MotorState of given gripper
+    /// @param name name of the gripper to get info on
+    /// @returns pointer to Gripper
+    Gripper* get_gripper_info(const std::string& name);
 
-  /// @brief Get ordered vector that determines the order in which gripper joint states are
-  ///   retrieved
-  /// @returns gripper order vector
-  std::vector<std::string> get_gripper_order();
+    /// @brief Get ordered vector that determines the order in which gripper
+    /// joint states are
+    ///   retrieved
+    /// @returns gripper order vector
+    std::vector<std::string> get_gripper_order();
 
-  /// @brief Get the joint state index of a joint
-  /// @param name the name of the motor to get the js index of
-  /// @returns the js index of the given joint
-  size_t get_js_index(const std::string & name);
+    /// @brief Get the joint state index of a joint
+    /// @param name the name of the motor to get the js index of
+    /// @returns the js index of the given joint
+    size_t get_js_index(const std::string& name);
 
-  /// @brief Determine if given joint is a gripper
-  /// @param name name of the joint
-  /// @returns true if a gripper, false otherwise
-  bool is_motor_gripper(const std::string & name);
+    /// @brief Determine if given joint is a gripper
+    /// @param name name of the joint
+    /// @returns true if a gripper, false otherwise
+    bool is_motor_gripper(const std::string& name);
 
-  /// @brief Send the specified joint group to its sleep configuration
-  /// @param name group name to send to sleep configuration; defaults to 'all'
-  /// @param blocking: (optional) whether the function should wait to return control to the user
-  ///   until the robot finishes moving; false by default
-  bool go_to_sleep_configuration(
-    const std::string & name,
-    const bool blocking = false);
+    /// @brief Send the specified joint group to its sleep configuration
+    /// @param name group name to send to sleep configuration; defaults to 'all'
+    /// @param blocking: (optional) whether the function should wait to return
+    /// control to the user
+    ///   until the robot finishes moving; false by default
+    bool go_to_sleep_configuration(const std::string& name, const bool blocking = false);
 
-  /// @brief Send the specified joint group to its home configuration
-  /// @param name group name to send to home configuration; defaults to 'all'
-  /// @param blocking: (optional) whether the function should wait to return control to the user
-  ///   until the robot finishes moving; false by default
-  bool go_to_home_configuration(
-    const std::string & name,
-    const bool blocking = false);
+    /// @brief Send the specified joint group to its home configuration
+    /// @param name group name to send to home configuration; defaults to 'all'
+    /// @param blocking: (optional) whether the function should wait to return
+    /// control to the user
+    ///   until the robot finishes moving; false by default
+    bool go_to_home_configuration(const std::string& name, const bool blocking = false);
 
-private:
-  // Pointer to the 'all' group (makes updating joint states more efficient)
-  JointGroup * all_ptr;
+  private:
+    // Pointer to the 'all' group (makes updating joint states more efficient)
+    JointGroup* all_ptr;
 
-  // DynamixelWorkbench object used to easily communicate with any DYNAMIXEL servo
-  DynamixelWorkbench dxl_wb;
+    // DynamixelWorkbench object used to easily communicate with any DYNAMIXEL
+    // servo
+    DynamixelWorkbench dxl_wb;
 
-  // Holds all the information in the motor_configs YAML file
-  YAML::Node motor_configs;
+    // Holds all the information in the motor_configs YAML file
+    YAML::Node motor_configs;
 
-  // Holds all the information in the mode_configs YAML file
-  YAML::Node mode_configs;
+    // Holds all the information in the mode_configs YAML file
+    YAML::Node mode_configs;
 
-  // Holds the USB port name that connects to the U2D2
-  std::string port = DEFAULT_PORT;
+    // Holds the USB port name that connects to the U2D2
+    std::string port = DEFAULT_PORT;
 
-  // Vector containing all the desired EEPROM register values to command the motors at startup
-  std::vector<MotorRegVal> motor_info_vec;
+    // Vector containing all the desired EEPROM register values to command the
+    // motors at startup
+    std::vector<MotorRegVal> motor_info_vec;
 
-  // Vector containing the order in which multiple grippers (if present) are published in the
-  // JointState message
-  std::vector<std::string> gripper_order;
+    // Vector containing the order in which multiple grippers (if present) are
+    // published in the JointState message
+    std::vector<std::string> gripper_order;
 
-  // Dictionary mapping register names to information about them (like 'address' and expected 'data
-  // length')
-  std::unordered_map<std::string, const ControlItem *> control_items;
+    // Dictionary mapping register names to information about them (like
+    // 'address' and expected 'data length')
+    std::unordered_map<std::string, const ControlItem*> control_items;
 
-  // Dictionary mapping a joint's name with its 'sleep' position
-  std::unordered_map<std::string, float> sleep_map;
+    // Dictionary mapping a joint's name with its 'sleep' position
+    std::unordered_map<std::string, float> sleep_map;
 
-  // Dictionary mapping a joint group's name with information about it (as defined in the
-  // JointGroup struct)
-  std::unordered_map<std::string, JointGroup> group_map;
+    // Dictionary mapping a joint group's name with information about it (as
+    // defined in the JointGroup struct)
+    std::unordered_map<std::string, JointGroup> group_map;
 
-  // Dictionary mapping a motor's name with information about it (as defined in the MotorState
-  // struct)
-  std::unordered_map<std::string, MotorState> motor_map;
+    // Dictionary mapping a motor's name with information about it (as defined
+    // in the MotorState struct)
+    std::unordered_map<std::string, MotorState> motor_map;
 
-  // Dictionary mapping a motor's name with the names of its shadows - including itself
-  std::unordered_map<std::string, std::vector<std::string>> shadow_map;
+    // Dictionary mapping a motor's name with the names of its shadows -
+    // including itself
+    std::unordered_map<std::string, std::vector<std::string>> shadow_map;
 
-  // Dictionary mapping the name of either servo in a 2in1 motor with the other one (henceforth
-  // known as 'sister')
-  std::unordered_map<std::string, std::vector<std::string>> sister_map;
+    // Dictionary mapping the name of either servo in a 2in1 motor with the
+    // other one (henceforth known as 'sister')
+    std::unordered_map<std::string, std::vector<std::string>> sister_map;
 
-  // Dictionary mapping the name of a gripper motor with information about it (as defined in the
-  // Gripper struct)
-  std::unordered_map<std::string, Gripper> gripper_map;
+    // Dictionary mapping the name of a gripper motor with information about it
+    // (as defined in the Gripper struct)
+    std::unordered_map<std::string, Gripper> gripper_map;
 
-  // Dictionary mapping the name of a joint with its position in the JointState 'name' list
-  std::unordered_map<std::string, size_t> js_index_map;
+    // Dictionary mapping the name of a joint with its position in the
+    // JointState 'name' list
+    std::unordered_map<std::string, size_t> js_index_map;
 
-  // Vector containing the robot joint positions in [rad] at the last update
-  std::vector<float> robot_positions;
+    // Vector containing the robot joint positions in [rad] at the last update
+    std::vector<float> robot_positions;
 
-  // Vector containing the robot joint velocities in [rad/s] at the last update
-  std::vector<float> robot_velocities;
+    // Vector containing the robot joint velocities in [rad/s] at the last
+    // update
+    std::vector<float> robot_velocities;
 
-  // Vector containing the robot joint efforts in [mA] at the last update
-  std::vector<float> robot_efforts;
+    // Vector containing the robot joint efforts in [mA] at the last update
+    std::vector<float> robot_efforts;
 
-  /// Absolute filepath to the motor configs file
-  std::string filepath_motor_configs;
+    /// Absolute filepath to the motor configs file
+    std::string filepath_motor_configs;
 
-  /// Absolute filepath to the mode configs file
-  std::string filepath_mode_configs;
+    /// Absolute filepath to the mode configs file
+    std::string filepath_mode_configs;
 
-  /// true if the robot should write to the all servos' EEPROMs on startup, false otherwise
-  bool write_eeprom_on_startup;
+    /// true if the robot should write to the all servos' EEPROMs on startup,
+    /// false otherwise
+    bool write_eeprom_on_startup;
 
-  // Mutex for updating / getting joint states
-  std::mutex _mutex_js;
+    // Mutex for updating / getting joint states
+    std::mutex _mutex_js;
 
-  /// @brief Loads a robot-specific 'motor_configs' yaml file and populates class variables with
-  ///   its contents
-  bool retrieve_motor_configs(
-    std::string filepath_motor_configs,
-    std::string filepath_mode_configs);
+    /// @brief Loads a robot-specific 'motor_configs' yaml file and populates
+    /// class variables with
+    ///   its contents
+    bool retrieve_motor_configs(std::string filepath_motor_configs,
+                                std::string filepath_mode_configs);
 
-  /// @brief Initializes the port to communicate with the DYNAMIXEL servos
-  /// @returns True if the port was successfully opened; False otherwise
-  bool init_port();
+    /// @brief Initializes the port to communicate with the DYNAMIXEL servos
+    /// @returns True if the port was successfully opened; False otherwise
+    bool init_port();
 
-  /// @brief Pings all motors to make sure they can be found
-  /// @returns True if all motors were found; False otherwise
-  bool ping_motors();
+    /// @brief Pings all motors to make sure they can be found
+    /// @returns True if all motors were found; False otherwise
+    bool ping_motors();
 
-  /// @brief Writes some 'startup' EEPROM register values to the DYNAMIXEL servos
-  /// @returns True if all register values were written successfully; False otherwise
-  bool load_motor_configs();
+    /// @brief Writes some 'startup' EEPROM register values to the DYNAMIXEL
+    /// servos
+    /// @returns True if all register values were written successfully; False
+    /// otherwise
+    bool load_motor_configs();
 
-  /// @brief Retrieves information about 'Goal_XXX' and 'Present_XXX' registers
-  /// @returns true if succeeded to init control items, false otherwise
-  /// @details Info includes a register's name, address, and data length
-  bool init_controlItems();
+    /// @brief Retrieves information about 'Goal_XXX' and 'Present_XXX'
+    /// registers
+    /// @returns true if succeeded to init control items, false otherwise
+    /// @details Info includes a register's name, address, and data length
+    bool init_controlItems();
 
-  /// @brief Creates SyncWrite and SyncRead Handlers to write/read data to multiple motors
-  ///   simultaneously
-  /// @returns true if succeeded to init workbench handlers, false otherwise
-  bool init_workbench_handlers();
+    /// @brief Creates SyncWrite and SyncRead Handlers to write/read data to
+    /// multiple motors
+    ///   simultaneously
+    /// @returns true if succeeded to init workbench handlers, false otherwise
+    bool init_workbench_handlers();
 
-  /// @brief Loads a 'mode_configs' yaml file containing desired operating modes and sets up the
-  ///   motors accordingly
-  void init_operating_modes();
+    /// @brief Loads a 'mode_configs' yaml file containing desired operating
+    /// modes and sets up the
+    ///   motors accordingly
+    void init_operating_modes();
 
-  /// @brief Updates the joint states from the DYNAMIXELs
-  void read_joint_states();
+    /// @brief Updates the joint states from the DYNAMIXELs
+    void read_joint_states();
 };
 
 }  // namespace interbotix_xs

--- a/include/interbotix_xs_driver/xs_logging.hpp
+++ b/include/interbotix_xs_driver/xs_logging.hpp
@@ -34,21 +34,16 @@
 #include <string>
 
 // define logging macros
-#define XSLOG_DEBUG(...) interbotix_xs::logging::log( \
-    interbotix_xs::logging::Level::DEBUG, \
-    __VA_ARGS__)
-#define XSLOG_INFO(...) interbotix_xs::logging::log( \
-    interbotix_xs::logging::Level::INFO, \
-    __VA_ARGS__)
-#define XSLOG_WARN(...) interbotix_xs::logging::log( \
-    interbotix_xs::logging::Level::WARN, \
-    __VA_ARGS__)
-#define XSLOG_ERROR(...) interbotix_xs::logging::log( \
-    interbotix_xs::logging::Level::ERROR, \
-    __VA_ARGS__)
-#define XSLOG_FATAL(...) interbotix_xs::logging::log( \
-    interbotix_xs::logging::Level::FATAL, \
-    __VA_ARGS__)
+#define XSLOG_DEBUG(...)                                                                           \
+    interbotix_xs::logging::log(interbotix_xs::logging::Level::DEBUG, __VA_ARGS__)
+#define XSLOG_INFO(...)                                                                            \
+    interbotix_xs::logging::log(interbotix_xs::logging::Level::INFO, __VA_ARGS__)
+#define XSLOG_WARN(...)                                                                            \
+    interbotix_xs::logging::log(interbotix_xs::logging::Level::WARN, __VA_ARGS__)
+#define XSLOG_ERROR(...)                                                                           \
+    interbotix_xs::logging::log(interbotix_xs::logging::Level::ERROR, __VA_ARGS__)
+#define XSLOG_FATAL(...)                                                                           \
+    interbotix_xs::logging::log(interbotix_xs::logging::Level::FATAL, __VA_ARGS__)
 
 namespace interbotix_xs
 {
@@ -56,13 +51,12 @@ namespace interbotix_xs
 namespace logging
 {
 
-enum Level
-{
-  DEBUG = 0,
-  INFO = 1,
-  WARN = 2,
-  ERROR = 3,
-  FATAL = 4
+enum Level {
+    DEBUG = 0,
+    INFO = 1,
+    WARN = 2,
+    ERROR = 3,
+    FATAL = 4
 };
 
 // The logging level - anything higher than this level will be logged
@@ -70,7 +64,7 @@ static Level _level = Level::INFO;
 
 /// @brief Log a message
 /// @param level The level with which to log the message
-void log(Level level, const char * fmt, ...);
+void log(Level level, const char* fmt, ...);
 
 /// @brief Set the logging level
 /// @param level the new logging level
@@ -87,6 +81,5 @@ Level get_level();
 }  // namespace logging
 
 }  // namespace interbotix_xs
-
 
 #endif  // INTERBOTIX_XS_DRIVER__XS_LOGGING_HPP_

--- a/src/protocols.h
+++ b/src/protocols.h
@@ -2,30 +2,34 @@
 
 #include "nlohmann/json.hpp"
 
-namespace horizon {
-namespace widowx {
+namespace horizon
+{
+namespace widowx
+{
 
-struct GripperStatus {
-  float radian;
-  float distance;
-  NLOHMANN_DEFINE_TYPE_INTRUSIVE(GripperStatus, radian, distance);
+struct GripperStatus
+{
+    float radian;
+    float distance;
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE(GripperStatus, radian, distance);
 };
 
-struct ArmStatus {
-  std::array<float, 7> joint_positions;
-  std::array<float, 7> joint_velocities;
-  std::array<float, 7> joint_efforts;
-  NLOHMANN_DEFINE_TYPE_INTRUSIVE(ArmStatus, joint_positions, joint_velocities,
-                                 joint_efforts);
+struct ArmStatus
+{
+    std::array<float, 7> joint_positions;
+    std::array<float, 7> joint_velocities;
+    std::array<float, 7> joint_efforts;
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE(ArmStatus, joint_positions, joint_velocities, joint_efforts);
 };
 
-struct PositionBound {
-  PositionBound(float l, float u) : lower(l), upper(u) {
-  }
+struct PositionBound
+{
+    PositionBound(float l, float u) : lower(l), upper(u) {
+    }
 
-  float lower;
-  float upper;
-  NLOHMANN_DEFINE_TYPE_INTRUSIVE(PositionBound, lower, upper);
+    float lower;
+    float upper;
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE(PositionBound, lower, upper);
 };
 
 }  // namespace widowx

--- a/src/udp_client.cpp
+++ b/src/udp_client.cpp
@@ -6,44 +6,45 @@
 using boost::asio::ip::udp;
 
 int main() {
-  try {
-    boost::asio::io_service io_service;
+    try {
+        boost::asio::io_service io_service;
 
-    udp::resolver resolver(io_service);
-    udp::endpoint receiver_endpoint =
-        *resolver.resolve({udp::v4(), "localhost", "30001"}).begin();
-    udp::socket socket(io_service);
-    socket.open(udp::v4());
+        udp::resolver resolver(io_service);
+        udp::endpoint receiver_endpoint =
+            *resolver.resolve({udp::v4(), "localhost", "30001"}).begin();
+        udp::socket socket(io_service);
+        socket.open(udp::v4());
 
-    char buffer[2048];
+        char buffer[2048];
 
-    std::cout << "This is C++ UDP client REPL for WidowX 250s Arm.\n";
-    std::cout << "There are 3 types of commands that you can use.\n\n";
-    std::cout << "STATUS\n";
-    std::cout << "BOUNDS\n";
-    std::cout << "SETPOS 0.1 0 0 0 0 0 0\n\n";
-    std::cout << "Here SETPOS needs to be followed by 7 floating numbers.\n\n";
+        std::cout << "This is C++ UDP client REPL for WidowX 250s Arm.\n";
+        std::cout << "There are 3 types of commands that you can use.\n\n";
+        std::cout << "STATUS\n";
+        std::cout << "BOUNDS\n";
+        std::cout << "SETPOS 0.1 0 0 0 0 0 0\n\n";
+        std::cout << "Here SETPOS needs to be followed by 7 floating numbers.\n\n";
 
-    while (true) {
-      std::cout << "INPUT COMMAND> ";
-      std::cout.flush();
+        while (true) {
+            std::cout << "INPUT COMMAND> ";
+            std::cout.flush();
 
-      std::string message;
-      std::getline(std::cin, message);
+            std::string message;
+            std::getline(std::cin, message);
 
-      socket.send_to(boost::asio::buffer(message), receiver_endpoint);
+            socket.send_to(boost::asio::buffer(message), receiver_endpoint);
 
-      // Wait for a response
-      if (strncmp(message.c_str(), "SETPOS", 6) != 0) {
-        udp::endpoint sender_endpoint;
-        size_t len = socket.receive_from(boost::asio::buffer(buffer), sender_endpoint);
-        std::cout.write(buffer, len);
-        std::cout << std::endl;
-      }
+            // Wait for a response
+            if (strncmp(message.c_str(), "SETPOS", 6) != 0) {
+                udp::endpoint sender_endpoint;
+                size_t len = socket.receive_from(boost::asio::buffer(buffer), sender_endpoint);
+                std::cout.write(buffer, len);
+                std::cout << std::endl;
+            }
+        }
     }
-  } catch (std::exception& e) {
-    std::cerr << e.what() << std::endl;
-  }
+    catch (std::exception& e) {
+        std::cerr << e.what() << std::endl;
+    }
 
-  return 0;
+    return 0;
 }

--- a/src/udp_daemon.cpp
+++ b/src/udp_daemon.cpp
@@ -1,5 +1,7 @@
 #include "udp_daemon.h"
 
+#include <unistd.h>
+
 #include <atomic>
 #include <chrono>
 #include <cstdio>
@@ -7,157 +9,115 @@
 #include <cstring>
 #include <iostream>
 #include <string>
-#include <unistd.h>
 
+#include "interbotix_xs_driver/xs_common.hpp"   // Common variables and types
+#include "interbotix_xs_driver/xs_driver.hpp"   // The InterbotixDriverXS class
+#include "interbotix_xs_driver/xs_logging.hpp"  // Logging macros and utils
 #include "spdlog/spdlog.h"
-#include "interbotix_xs_driver/xs_logging.hpp" // Logging macros and utils
-#include "interbotix_xs_driver/xs_common.hpp"  // Common variables and types
-#include "interbotix_xs_driver/xs_driver.hpp"  // The InterbotixDriverXS class
 
 using boost::asio::ip::udp;
 
 namespace horizon::widowx
 {
-  namespace
-  {
+namespace
+{
 
-    // Convert a string like "1.23 4.5 3.3" into a vector<float> like {1.23, 4.5, 3.3}.
-    std::vector<float> ParseArray(char *text, size_t len)
-    {
-      std::vector<float> result{};
-      char *start = text;
-      for (; start - text < len; ++start)
-      {
+// Convert a string like "1.23 4.5 3.3" into a vector<float> like
+// {1.23, 4.5, 3.3}.
+std::vector<float> ParseArray(char* text, size_t len) {
+    std::vector<float> result{};
+    char* start = text;
+    for (; start - text < len; ++start) {
         if (!(std::isdigit(*start) || *start == '.' || *start == '-'))
-          continue;
+            continue;
         result.emplace_back(std::strtof(start, &start));
-      }
-      return result;
+    }
+    return result;
+}
+
+}  // namespace
+
+class UDPPusher
+{
+  public:
+    UDPPusher(InterbotixDriverXS* arm_low, const std::string& address, int port, bool sync = false)
+        : arm_low_(arm_low), address_(address), port_(port), sync_mode_(sync), socket_(io_service_),
+          thread_([this]() { Run(); }) {
     }
 
-  } // namespace
-
-  class UDPPusher
-  {
-   public:
-    UDPPusher(InterbotixDriverXS *arm_low,
-              const std::string &address,
-              int port,
-              bool sync = false)
-        : arm_low_(arm_low), address_(address), port_(port), sync_mode_(sync),
-          socket_(io_service_), thread_([this]()
-                                        { Run(); })
-    {
+    ~UDPPusher() {
+        kill_.store(true);
+        thread_.join();
     }
 
-    ~UDPPusher()
-    {
-      kill_.store(true);
-      thread_.join();
-    }
+    void Run() {
+        udp::resolver resolver(io_service_);
+        listener_endpoint_ =
+            *resolver.resolve({udp::v4(), address_, std::to_string(port_)}).begin();
+        socket_.open(udp::v4());
 
-    void Run()
-    {
-      udp::resolver resolver(io_service_);
-      listener_endpoint_ =
-          *resolver.resolve({udp::v4(), address_, std::to_string(port_)}).begin();
-      socket_.open(udp::v4());
+        boost::system::error_code error;
+        char data[2048];
 
-      boost::system::error_code error;
-      char data[2048];
-
-      // TODO(breakds): When the listener died it should be detected
-      // here and the push thread should terminate.
-      if (arm_low_ == nullptr)
-      {
-        // Mock case
-        for (int i = 0; i < 100; ++i)
-        {
-          std::sprintf(data,
-                        "%.3f %.3f %.3f %.3f %.3f %.3f %.3f",
-                        0.01f * i,
-                        0.02f * i,
-                        0.03f * i,
-                        0.04f * i,
-                        0.05f * i,
-                        0.06f * i,
-                        0.07f * i);
-          int ret = socket_.send_to(
-              boost::asio::buffer(std::string(data)), listener_endpoint_, 0, error);
-          std::this_thread::sleep_for(std::chrono::milliseconds(100));
-          if (kill_.load())
-          {
-            break;
-          }
+        // TODO(breakds): When the listener died it should be detected
+        // here and the push thread should terminate.
+        if (arm_low_ == nullptr) {
+            // Mock case
+            for (int i = 0; i < 100; ++i) {
+                std::sprintf(data, "%.3f %.3f %.3f %.3f %.3f %.3f %.3f", 0.01f * i, 0.02f * i,
+                             0.03f * i, 0.04f * i, 0.05f * i, 0.06f * i, 0.07f * i);
+                int ret = socket_.send_to(boost::asio::buffer(std::string(data)),
+                                          listener_endpoint_, 0, error);
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                if (kill_.load()) {
+                    break;
+                }
+            }
         }
-      }
-      else
-      {
-        // Actual case
-        GetStatusAndSend(0); // initial send
-        while (true)
-        {
-          GetStatusAndSend(sync_mode_ ? -1 : 1);
-          if (kill_.load())
-          {
-            break;
-          }
+        else {
+            // Actual case
+            GetStatusAndSend(0);  // initial send
+            while (true) {
+                GetStatusAndSend(sync_mode_ ? -1 : 1);
+                if (kill_.load()) {
+                    break;
+                }
+            }
         }
-      }
-      socket_.close();
+        socket_.close();
     }
 
-    void GetStatusAndSend(int ms = 1)
-    {
-      if (ms < 0)
-      {
-        // disable reading
-        sleep(10);
-        return;
-      }
-      boost::system::error_code error;
-      char data[2048];
-      std::vector<float> positions(7);
-      std::vector<float> velocities(7);
-      std::vector<float> efforts(7);
-      bool succ = arm_low_->get_joint_states(
-          "all", &positions, &velocities, &efforts);
-      assert(succ);
+    void GetStatusAndSend(int ms = 1) {
+        if (ms < 0) {
+            // disable reading
+            sleep(10);
+            return;
+        }
+        boost::system::error_code error;
+        char data[2048];
+        std::vector<float> positions(7);
+        std::vector<float> velocities(7);
+        std::vector<float> efforts(7);
+        bool succ = arm_low_->get_joint_states("all", &positions, &velocities, &efforts);
+        assert(succ);
 
-      std::sprintf(data,
-                    "%.8f %.8f %.8f %.8f %.8f %.8f %.8f "
-                    "%.8f %.8f %.8f %.8f %.8f %.8f %.8f "
-                    "%.8f %.8f %.8f %.8f %.8f %.8f %.8f",
-                    positions[0],
-                    positions[1],
-                    positions[2],
-                    positions[3],
-                    positions[4],
-                    positions[5],
-                    positions[6],
-                    velocities[0],
-                    velocities[1],
-                    velocities[2],
-                    velocities[3],
-                    velocities[4],
-                    velocities[5],
-                    velocities[6],
-                    efforts[0],
-                    efforts[1],
-                    efforts[2],
-                    efforts[3],
-                    efforts[4],
-                    efforts[5],
-                    efforts[6]);
-      int ret = socket_.send_to(
-          boost::asio::buffer(std::string(data)), listener_endpoint_, 0, error);
-      std::this_thread::sleep_for(std::chrono::milliseconds(ms));
+        std::sprintf(data,
+                     "%.8f %.8f %.8f %.8f %.8f %.8f %.8f "
+                     "%.8f %.8f %.8f %.8f %.8f %.8f %.8f "
+                     "%.8f %.8f %.8f %.8f %.8f %.8f %.8f",
+                     positions[0], positions[1], positions[2], positions[3], positions[4],
+                     positions[5], positions[6], velocities[0], velocities[1], velocities[2],
+                     velocities[3], velocities[4], velocities[5], velocities[6], efforts[0],
+                     efforts[1], efforts[2], efforts[3], efforts[4], efforts[5], efforts[6]);
+        int ret =
+            socket_.send_to(boost::asio::buffer(std::string(data)), listener_endpoint_, 0, error);
+        std::this_thread::sleep_for(std::chrono::milliseconds(ms));
     }
 
-   private:
+  private:
     // When true, write command and then read state
     bool sync_mode_ = false;
-    InterbotixDriverXS *arm_low_ = nullptr;
+    InterbotixDriverXS* arm_low_ = nullptr;
     std::string address_;
     int port_;
     boost::asio::io_service io_service_;
@@ -165,47 +125,43 @@ namespace horizon::widowx
     udp::socket socket_;
     std::thread thread_;
     std::atomic<bool> kill_{false};
-  };
+};
 
-  UDPDaemon::UDPDaemon(int port,
-                       bool sync,
-                       std::string filepath_motor_configs,
-                       std::string filepath_mode_configs)
-      : port_(port), sync_mode_(sync), filepath_motor_configs_(filepath_motor_configs),
-        filepath_mode_configs_(filepath_mode_configs) {
-    if (filepath_motor_configs == "" || filepath_mode_configs == "")
-    {
-      char *username;
-      username = getlogin();
+UDPDaemon::UDPDaemon(int port, bool sync, std::string filepath_motor_configs,
+                     std::string filepath_mode_configs)
+    : port_(port), sync_mode_(sync), filepath_motor_configs_(filepath_motor_configs),
+      filepath_mode_configs_(filepath_mode_configs) {
+    if (filepath_motor_configs == "" || filepath_mode_configs == "") {
+        char* username;
+        username = getlogin();
 
-      if (username == nullptr) {
-        spdlog::error("getlogin() error");
-        std::exit(EXIT_FAILURE);
-      }
-      std::string path = "/home/";
-      path += username;
-      path += "/interbotix_xs_driver";
-      filepath_motor_configs_ = path + "/wx250s_motor_config.yaml";
-      filepath_mode_configs_ = path + "/mode_configs.yaml";
+        if (username == nullptr) {
+            spdlog::error("getlogin() error");
+            std::exit(EXIT_FAILURE);
+        }
+        std::string path = "/home/";
+        path += username;
+        path += "/interbotix_xs_driver";
+        filepath_motor_configs_ = path + "/wx250s_motor_config.yaml";
+        filepath_mode_configs_ = path + "/mode_configs.yaml";
     }
-  }
+}
 
-  void UDPDaemon::Start()
-  {
+void UDPDaemon::Start() {
     try {
-      io_service_ = std::make_unique<boost::asio::io_service>();
-      socket_ =
-          std::make_unique<udp::socket>(*io_service_, udp::endpoint(udp::v4(), port_));
-    } catch (std::exception& e) {
-      spdlog::critical("Fatal error while creating the socket: {}", e.what());
-      std::exit(EXIT_FAILURE);
+        io_service_ = std::make_unique<boost::asio::io_service>();
+        socket_ = std::make_unique<udp::socket>(*io_service_, udp::endpoint(udp::v4(), port_));
+    }
+    catch (std::exception& e) {
+        spdlog::critical("Fatal error while creating the socket: {}", e.what());
+        std::exit(EXIT_FAILURE);
     }
 
     bool write_eeprom_on_startup = true;
     std::string logging_level = "DEBUG";
 
-    arm_low_ = std::make_unique<InterbotixDriverXS>(
-        filepath_motor_configs_, filepath_mode_configs_, write_eeprom_on_startup, logging_level);
+    arm_low_ = std::make_unique<InterbotixDriverXS>(filepath_motor_configs_, filepath_mode_configs_,
+                                                    write_eeprom_on_startup, logging_level);
 
     spdlog::info("UDP Daemon for WidowX 250s Arm started successfully.");
     std::unique_ptr<UDPPusher> pusher;
@@ -215,59 +171,66 @@ namespace horizon::widowx
     size_t content_size = 0;
 
     while (true) {
-      udp::endpoint sender_endpoint;
-      // Below is a blocking call that returns as soon as there is data in. The
-      // information about the sender is stored in the sneder_endpoint and the
-      // message content will be in data.
-      try {
-        // auto start = std::chrono::high_resolution_clock::now();
-        content_size = socket_->receive_from(boost::asio::buffer(data), sender_endpoint);
-        // auto end = std::chrono::high_resolution_clock::now();
-        // std::chrono::duration<double> diff = end - start;
-        // std::cout << "UDPDaemon: receive cmd from client took: " << diff.count() << " seconds" << std::endl;
-        // TODO(breakds): Do I need to force set null ending?
-      } catch (std::exception& e) {
-        spdlog::error("Error in receiving from socket: {}", e.what());
-        continue;
-      }
-
-      if (std::strncmp(data, CMD_STATUS, 6) == 0) {
-        nlohmann::json status = GetStatus();
-        socket_->send_to(boost::asio::buffer(status.dump()), sender_endpoint);
-      } else if (std::strncmp(data, CMD_BOUNDS, 6) == 0) {
-        nlohmann::json bounds = GetBounds();
-        socket_->send_to(boost::asio::buffer(bounds.dump()), sender_endpoint);
-      } else if (std::strncmp(data, CMD_SETPOS, 6) == 0) {
-        std::vector<float> positions = ParseArray(data + 7, content_size - 7);
-        // TODO(breakds): Check positions has 7 numbers.
-        SetPosition(positions);
-        // read after 15ms wait, to give policy 2ms, network 1ms and 2ms buffer time.
-        if (sync_mode_) {
-          for (int i = 0; i < 1; ++i) {
-            std::this_thread::sleep_for(std::chrono::milliseconds(15));
-            pusher->GetStatusAndSend(0);
-          }
+        udp::endpoint sender_endpoint;
+        // Below is a blocking call that returns as soon as there is data in.
+        // The information about the sender is stored in the sneder_endpoint and
+        // the message content will be in data.
+        try {
+            // auto start = std::chrono::high_resolution_clock::now();
+            content_size = socket_->receive_from(boost::asio::buffer(data), sender_endpoint);
+            // auto end = std::chrono::high_resolution_clock::now();
+            // std::chrono::duration<double> diff = end - start;
+            // std::cout << "UDPDaemon: receive cmd from client took: " <<
+            // diff.count() << " seconds" << std::endl;
+            // TODO(breakds): Do I need to force set null ending?
         }
-      } else if (std::strncmp(data, CMD_LISTEN, 6) == 0) {
-        std::string listener_address = sender_endpoint.address().to_string();
-        int listener_port            = std::stoi(std::string(data + 7, content_size - 7));
-        spdlog::info("Request LISTEN from {}:{}", listener_address, listener_port);
-        pusher =
-            std::make_unique<UDPPusher>(arm_low_.get(), listener_address, listener_port, sync_mode_);
-      } else {
-        spdlog::error("Invalid command: {}", data);
-      }
-    }
-  }
+        catch (std::exception& e) {
+            spdlog::error("Error in receiving from socket: {}", e.what());
+            continue;
+        }
 
-  void UDPDaemon::StartMock() {
+        if (std::strncmp(data, CMD_STATUS, 6) == 0) {
+            nlohmann::json status = GetStatus();
+            socket_->send_to(boost::asio::buffer(status.dump()), sender_endpoint);
+        }
+        else if (std::strncmp(data, CMD_BOUNDS, 6) == 0) {
+            nlohmann::json bounds = GetBounds();
+            socket_->send_to(boost::asio::buffer(bounds.dump()), sender_endpoint);
+        }
+        else if (std::strncmp(data, CMD_SETPOS, 6) == 0) {
+            std::vector<float> positions = ParseArray(data + 7, content_size - 7);
+            // TODO(breakds): Check positions has 7 numbers.
+            SetPosition(positions);
+            // read after 15ms wait, to give policy 2ms, network 1ms and 2ms
+            // buffer time.
+            if (sync_mode_) {
+                for (int i = 0; i < 1; ++i) {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(15));
+                    pusher->GetStatusAndSend(0);
+                }
+            }
+        }
+        else if (std::strncmp(data, CMD_LISTEN, 6) == 0) {
+            std::string listener_address = sender_endpoint.address().to_string();
+            int listener_port = std::stoi(std::string(data + 7, content_size - 7));
+            spdlog::info("Request LISTEN from {}:{}", listener_address, listener_port);
+            pusher = std::make_unique<UDPPusher>(arm_low_.get(), listener_address, listener_port,
+                                                 sync_mode_);
+        }
+        else {
+            spdlog::error("Invalid command: {}", data);
+        }
+    }
+}
+
+void UDPDaemon::StartMock() {
     try {
-      io_service_ = std::make_unique<boost::asio::io_service>();
-      socket_ =
-          std::make_unique<udp::socket>(*io_service_, udp::endpoint(udp::v4(), port_));
-    } catch (std::exception& e) {
-      spdlog::critical("Fatal error while creating the socket: {}", e.what());
-      std::exit(EXIT_FAILURE);
+        io_service_ = std::make_unique<boost::asio::io_service>();
+        socket_ = std::make_unique<udp::socket>(*io_service_, udp::endpoint(udp::v4(), port_));
+    }
+    catch (std::exception& e) {
+        spdlog::critical("Fatal error while creating the socket: {}", e.what());
+        std::exit(EXIT_FAILURE);
     }
 
     spdlog::info("Start mocking UDP Daemon");
@@ -278,94 +241,82 @@ namespace horizon::widowx
     size_t content_size = 0;
 
     while (true) {
-      udp::endpoint sender_endpoint;
-      // Below is a blocking call that returns as soon as there is data in. The
-      // information about the sender is stored in the sneder_endpoint and the
-      // message content will be in data.
-      try {
-        content_size = socket_->receive_from(boost::asio::buffer(data), sender_endpoint);
-        // TODO(breakds): Do I need to force set null ending?
-      } catch (std::exception& e) {
-        spdlog::error("Error in receiving from socket: {}", e.what());
-        continue;
-      }
+        udp::endpoint sender_endpoint;
+        // Below is a blocking call that returns as soon as there is data in.
+        // The information about the sender is stored in the sneder_endpoint and
+        // the message content will be in data.
+        try {
+            content_size = socket_->receive_from(boost::asio::buffer(data), sender_endpoint);
+            // TODO(breakds): Do I need to force set null ending?
+        }
+        catch (std::exception& e) {
+            spdlog::error("Error in receiving from socket: {}", e.what());
+            continue;
+        }
 
-      if (std::strncmp(data, CMD_STATUS, 6) == 0) {
-        nlohmann::json status = ArmStatus{
-            .joint_positions = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
-            .joint_velocities = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
-            .joint_efforts = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0}
-        };
-        socket_->send_to(boost::asio::buffer(status.dump()), sender_endpoint);
-      } else if (std::strncmp(data, CMD_BOUNDS, 6) == 0) {
-        nlohmann::json bounds = {
-            PositionBound(-1.0, 1.0),
-            PositionBound(-1.0, 1.0),
-            PositionBound(-1.0, 1.0),
-            PositionBound(-1.0, 1.0),
-            PositionBound(-1.0, 1.0),
-            PositionBound(-1.0, 1.0),
-            PositionBound(-0.068, 0.0),
-        };
-        socket_->send_to(boost::asio::buffer(bounds.dump()), sender_endpoint);
-      } else if (std::strncmp(data, CMD_SETPOS, 6) == 0) {
-        std::vector<float> positions = ParseArray(data + 8, content_size - 8);
-        spdlog::info("Set joint positions to [{}, {}, {}, {}, {}, {}] + {}",
-                    positions[0],
-                    positions[1],
-                    positions[2],
-                    positions[3],
-                    positions[4],
-                    positions[5],
-                    positions[6]);
-      } else if (std::strncmp(data, CMD_LISTEN, 6) == 0) {
-        std::string listener_address = sender_endpoint.address().to_string();
-        int listener_port            = std::stoi(std::string(data + 7, content_size - 7));
-        spdlog::info("Request LISTEN from {}:{}", listener_address, listener_port);
-        pusher = std::make_unique<UDPPusher>(nullptr, listener_address, listener_port);
-      } else {
-        spdlog::error("Invalid command: {}", data);
-      }
+        if (std::strncmp(data, CMD_STATUS, 6) == 0) {
+            nlohmann::json status = ArmStatus{.joint_positions = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
+                                              .joint_velocities = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
+                                              .joint_efforts = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0}};
+            socket_->send_to(boost::asio::buffer(status.dump()), sender_endpoint);
+        }
+        else if (std::strncmp(data, CMD_BOUNDS, 6) == 0) {
+            nlohmann::json bounds = {
+                PositionBound(-1.0, 1.0),   PositionBound(-1.0, 1.0), PositionBound(-1.0, 1.0),
+                PositionBound(-1.0, 1.0),   PositionBound(-1.0, 1.0), PositionBound(-1.0, 1.0),
+                PositionBound(-0.068, 0.0),
+            };
+            socket_->send_to(boost::asio::buffer(bounds.dump()), sender_endpoint);
+        }
+        else if (std::strncmp(data, CMD_SETPOS, 6) == 0) {
+            std::vector<float> positions = ParseArray(data + 8, content_size - 8);
+            spdlog::info("Set joint positions to [{}, {}, {}, {}, {}, {}] + {}", positions[0],
+                         positions[1], positions[2], positions[3], positions[4], positions[5],
+                         positions[6]);
+        }
+        else if (std::strncmp(data, CMD_LISTEN, 6) == 0) {
+            std::string listener_address = sender_endpoint.address().to_string();
+            int listener_port = std::stoi(std::string(data + 7, content_size - 7));
+            spdlog::info("Request LISTEN from {}:{}", listener_address, listener_port);
+            pusher = std::make_unique<UDPPusher>(nullptr, listener_address, listener_port);
+        }
+        else {
+            spdlog::error("Invalid command: {}", data);
+        }
     }
-  }  // end of StartMock()
+}  // end of StartMock()
 
-  void UDPDaemon::SetPosition(const std::vector<float>& positions) {
+void UDPDaemon::SetPosition(const std::vector<float>& positions) {
     if (positions.size() != 7) {
-      spdlog::error("SetPosition() cannot handle inputs with a size of {}",
-                    positions.size());
-      return;
+        spdlog::error("SetPosition() cannot handle inputs with a size of {}", positions.size());
+        return;
     }
     arm_low_->write_position_commands("all", positions);
-  }
+}
 
-  ArmStatus UDPDaemon::GetStatus() {
+ArmStatus UDPDaemon::GetStatus() {
     std::vector<float> positions(7);
     std::vector<float> velocities(7);
     std::vector<float> efforts(7);
-    bool succ = arm_low_->get_joint_states(
-        "all", &positions, &velocities, &efforts);
+    bool succ = arm_low_->get_joint_states("all", &positions, &velocities, &efforts);
     assert(succ);
 
     return ArmStatus{
-        .joint_positions =
-            {positions[0], positions[1], positions[2], positions[3], positions[4], positions[5], positions[6]},
-        .joint_velocities =
-            {velocities[0], velocities[1], velocities[2], velocities[3], velocities[4], velocities[5], velocities[6]},
-        .joint_efforts =
-            {efforts[0], efforts[1], efforts[2], efforts[3], efforts[4], efforts[5], efforts[6]},
+        .joint_positions = {positions[0], positions[1], positions[2], positions[3], positions[4],
+                            positions[5], positions[6]},
+        .joint_velocities = {velocities[0], velocities[1], velocities[2], velocities[3],
+                             velocities[4], velocities[5], velocities[6]},
+        .joint_efforts = {efforts[0], efforts[1], efforts[2], efforts[3], efforts[4], efforts[5],
+                          efforts[6]},
     };
-  }
+}
 
-  std::vector<PositionBound> UDPDaemon::GetBounds() {
+std::vector<PositionBound> UDPDaemon::GetBounds() {
     return {
-        PositionBound(-0.068, 0.0),
-        PositionBound(-0.068, 0.0),
-        PositionBound(-0.068, 0.0),
-        PositionBound(-0.068, 0.0),
-        PositionBound(-0.068, 0.0),
-        PositionBound(-0.068, 0.0),
+        PositionBound(-0.068, 0.0), PositionBound(-0.068, 0.0), PositionBound(-0.068, 0.0),
+        PositionBound(-0.068, 0.0), PositionBound(-0.068, 0.0), PositionBound(-0.068, 0.0),
         PositionBound(-0.068, 0.0),
     };
-  }
+}
 
 }  // namespace horizon::widowx

--- a/src/udp_daemon.h
+++ b/src/udp_daemon.h
@@ -7,52 +7,55 @@
 #include <vector>
 
 #include "boost/asio.hpp"
-#include "protocols.h"
 #include "interbotix_xs_driver/xs_driver.hpp"
+#include "protocols.h"
 
 using InterbotixDriverXS = interbotix_xs::InterbotixDriverXS;
 
-namespace horizon {
-namespace widowx {
+namespace horizon
+{
+namespace widowx
+{
 
-class UDPDaemon {
- public:
-  using udp = boost::asio::ip::udp;
+class UDPDaemon
+{
+  public:
+    using udp = boost::asio::ip::udp;
 
-  static constexpr char CMD_STATUS[] = "STATUS";
-  static constexpr char CMD_BOUNDS[] = "BOUNDS";
-  static constexpr char CMD_SETPOS[] = "SETPOS";
-  static constexpr char CMD_LISTEN[] = "LISTEN";
+    static constexpr char CMD_STATUS[] = "STATUS";
+    static constexpr char CMD_BOUNDS[] = "BOUNDS";
+    static constexpr char CMD_SETPOS[] = "SETPOS";
+    static constexpr char CMD_LISTEN[] = "LISTEN";
 
-  explicit UDPDaemon(int port, bool sync=false, std::string filepath_motor_configs="",
-                     std::string filepath_mode_configs="");
+    explicit UDPDaemon(int port, bool sync = false, std::string filepath_motor_configs = "",
+                       std::string filepath_mode_configs = "");
 
-  void Start();
+    void Start();
 
-  // This does not actually connect to the Sagittarius robotic arm and
-  // is useful for testing UDP networking.
-  void StartMock();
+    // This does not actually connect to the Sagittarius robotic arm and
+    // is useful for testing UDP networking.
+    void StartMock();
 
- private:
-  // ---------- Actual Command Handlers ----------
+  private:
+    // ---------- Actual Command Handlers ----------
 
-  // Command: STATUS
-  ArmStatus GetStatus();
+    // Command: STATUS
+    ArmStatus GetStatus();
 
-  // Command: SETPOS
-  void SetPosition(const std::vector<float>& positions);
+    // Command: SETPOS
+    void SetPosition(const std::vector<float>& positions);
 
-  // Command: BOUNDS
-  std::vector<PositionBound> GetBounds();
+    // Command: BOUNDS
+    std::vector<PositionBound> GetBounds();
 
-  int port_;
-  std::unique_ptr<boost::asio::io_service> io_service_{};
-  std::unique_ptr<udp::socket> socket_{};
+    int port_;
+    std::unique_ptr<boost::asio::io_service> io_service_{};
+    std::unique_ptr<udp::socket> socket_{};
 
-  // Low level arm interface.
-  std::unique_ptr<InterbotixDriverXS> arm_low_;
-  std::string filepath_motor_configs_, filepath_mode_configs_;
-  bool sync_mode_ = false;
+    // Low level arm interface.
+    std::unique_ptr<InterbotixDriverXS> arm_low_;
+    std::string filepath_motor_configs_, filepath_mode_configs_;
+    bool sync_mode_ = false;
 };
 
 }  // namespace widowx

--- a/src/wx_serverd.cpp
+++ b/src/wx_serverd.cpp
@@ -9,36 +9,40 @@
 using horizon::widowx::UDPDaemon;
 
 template <typename T>
-T GetEnv(const char *name, T default_value) {
-  const char *value = std::getenv(name);
-  if (value == nullptr) {
-    return default_value;
-  }
+T GetEnv(const char* name, T default_value) {
+    const char* value = std::getenv(name);
+    if (value == nullptr) {
+        return default_value;
+    }
 
-  if constexpr (std::is_same_v<T, int>) {
-    return std::stoi(value);
-  } else if constexpr (std::is_same_v<T, bool>) {
-    return (std::strcmp(value, "yes") == 0 || std::strcmp(value, "1") == 0 ||
-            std::strcmp(value, "true") == 0 || std::strcmp(value, "T") == 0);
-  } else if constexpr (std::is_same_v<T, std::string>) {
-    return std::string(value);
-  } else {
-    spdlog::critical("Unspported type for GetEnv, name = '{}'", name);
-    std::exit(EXIT_FAILURE);
-  }
+    if constexpr (std::is_same_v<T, int>) {
+        return std::stoi(value);
+    }
+    else if constexpr (std::is_same_v<T, bool>) {
+        return (std::strcmp(value, "yes") == 0 || std::strcmp(value, "1") == 0 ||
+                std::strcmp(value, "true") == 0 || std::strcmp(value, "T") == 0);
+    }
+    else if constexpr (std::is_same_v<T, std::string>) {
+        return std::string(value);
+    }
+    else {
+        spdlog::critical("Unspported type for GetEnv, name = '{}'", name);
+        std::exit(EXIT_FAILURE);
+    }
 }
 
-int main(int argc, char**argv) {
-  int sync = 0;
-  if (argc > 1)
-    sync = atoi(argv[1]);
-  UDPDaemon daemon(GetEnv<int>("WX_PORT", 9211), (bool) sync);
+int main(int argc, char** argv) {
+    int sync = 0;
+    if (argc > 1)
+        sync = atoi(argv[1]);
+    UDPDaemon daemon(GetEnv<int>("WX_PORT", 9211), (bool)sync);
 
-  if (GetEnv<bool>("WXD_MOCK", false)) {
-    // Run in mock mode
-    daemon.StartMock();
-  } else {
-    daemon.Start();
-  }
-  return 0;
+    if (GetEnv<bool>("WXD_MOCK", false)) {
+        // Run in mock mode
+        daemon.StartMock();
+    }
+    else {
+        daemon.Start();
+    }
+    return 0;
 }

--- a/src/xs_driver.cpp
+++ b/src/xs_driver.cpp
@@ -28,1431 +28,1243 @@
 
 #include "interbotix_xs_driver/xs_driver.hpp"
 
-#include <string>
-#include <vector>
 #include <memory>
 #include <mutex>
+#include <string>
 #include <thread>
 #include <unordered_map>
+#include <vector>
 
 namespace interbotix_xs
 {
 
-InterbotixDriverXS::InterbotixDriverXS(
-  std::string filepath_motor_configs,
-  std::string filepath_mode_configs,
-  bool write_eeprom_on_startup,
-  std::string logging_level)
-{
-  XSLOG_INFO(
-    "Using Interbotix X-Series Driver Version: 'v%d.%d.%d'.",
-    VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH);
-  logging::set_level(logging_level);
-  XSLOG_INFO("Using logging level '%s'.", logging_level.c_str());
-  if (!retrieve_motor_configs(filepath_motor_configs, filepath_mode_configs)) {
-    throw std::runtime_error("Failed due to bad config.");
-  }
-
-  if (!init_port()) {
-    throw std::runtime_error("Failed to open port.");
-  }
-
-  if (!ping_motors()) {
-    XSLOG_FATAL("Failed to find all motors. Shutting down...");
-    throw std::runtime_error("Failed to find all motors.");
-  }
-
-  if (write_eeprom_on_startup) {
-    if (!load_motor_configs()) {
-      XSLOG_FATAL("Failed to write configurations to all motors. Shutting down...");
-      throw std::runtime_error("Failed to write configurations to all motors.");
-    }
-    XSLOG_WARN(
-      "Writing startup register values to EEPROM. This only needs to be done once on a robot if "
-      "using a default motor config file, or after a motor config file has been modified. "
-      "Can set `write_eeprom_on_startup` to false from now on.");
-  } else {
-    XSLOG_INFO("Skipping Load Configs.");
-  }
-
-  init_controlItems();
-  init_workbench_handlers();
-  init_operating_modes();
-  init_controlItems();
-  XSLOG_INFO("Interbotix X-Series Driver is up!");
-}
-
-bool InterbotixDriverXS::set_operating_modes(
-  const std::string & cmd_type,
-  const std::string & name,
-  const std::string & mode,
-  const std::string profile_type,
-  const int32_t profile_velocity,
-  const int32_t profile_acceleration)
-{
-  if (cmd_type == cmd_type::GROUP && group_map.count(name) > 0) {
-    // group case
-    for (auto const & joint_name : get_group_info(name)->joint_names) {
-      set_joint_operating_mode(
-        joint_name,
-        mode,
-        profile_type,
-        profile_velocity,
-        profile_acceleration);
-    }
-    get_group_info(name)->mode = mode;
-    get_group_info(name)->profile_type = profile_type;
-    get_group_info(name)->profile_velocity = profile_velocity;
-    get_group_info(name)->profile_acceleration = profile_acceleration;
-    XSLOG_INFO(
-      "The operating mode for the '%s' group was changed to '%s' with profile type '%s'.",
-      name.c_str(), mode.c_str(), profile_type.c_str());
-  } else if (cmd_type == cmd_type::SINGLE && motor_map.count(name) > 0) {
-    // single case
-    set_joint_operating_mode(
-      name,
-      mode,
-      profile_type,
-      profile_velocity,
-      profile_acceleration);
-    XSLOG_INFO(
-      "The operating mode for the '%s' joint was changed to '%s' with profile type '%s'.",
-      name.c_str(), mode.c_str(), profile_type.c_str());
-  } else if ( // NOLINT https://github.com/ament/ament_lint/issues/158
-    (cmd_type == cmd_type::GROUP && group_map.count(name) == 0) ||
-    (cmd_type == cmd_type::SINGLE && motor_map.count(name) == 0))
-  {
-    // case where specified joint or group does not exist depending on cmd_type
-    XSLOG_ERROR(
-      "The '%s' joint/group does not exist. Was it added to the motor config file?",
-      name.c_str());
-    return false;
-  } else {
-    // case where cmd_type is invalid (i.e. not 'group' or 'single')
-    XSLOG_ERROR("Invalid command for argument 'cmd_type' while setting operating mode.");
-    return false;
-  }
-  return true;
-}
-
-bool InterbotixDriverXS::set_joint_operating_mode(
-  const std::string & name,
-  const std::string & mode,
-  const std::string profile_type,
-  const int32_t profile_velocity,
-  const int32_t profile_acceleration)
-{
-  // torque off sister servos
-  for (auto const & joint_name : sister_map[name]) {
-    dxl_wb.torque(motor_map[joint_name].motor_id, false);
-    XSLOG_DEBUG("ID: %d, torqued off.", motor_map[joint_name].motor_id);
-  }
-
-  for (auto const & motor_name : shadow_map[name]) {
-    int32_t drive_mode;
-    // read drive mode for each shadow
-    dxl_wb.itemRead(motor_map[motor_name].motor_id, "Drive_Mode", &drive_mode);
-    std::bitset<8> drive_mode_bitset_read = drive_mode, drive_mode_bitset_write = drive_mode;
-    XSLOG_DEBUG(
-      "ID: %d, read Drive_Mode [%s].",
-      motor_map[motor_name].motor_id, drive_mode_bitset_read.to_string().c_str());
-    // The 2nd (0x04) bit of the Drive_Mode register sets Profile Configuration
-    // [0/false]: Velocity-based Profile: Create a Profile based on Velocity
-    // [1/true]: Time-based Profile: Create Profile based on Time
-    if (profile_type == profile::TIME) {
-      drive_mode_bitset_write.set(2);  // turn ON for time profile
-    } else if (profile_type == profile::VELOCITY) {
-      drive_mode_bitset_write.reset(2);  // turn OFF for velocity profile
-    }
-    // if not correct, write the correct drive mode based on the profile type
-    // see https://emanual.robotis.com/docs/en/dxl/x/xm430-w350/#drive-mode for details
-    if (!drive_mode_bitset_read.test(2) && profile_type == profile::TIME) {
-      // if the 2nd read bit was OFF and profile_type is time, write new Drive_Mode
-      dxl_wb.itemWrite(
-        motor_map[motor_name].motor_id, "Drive_Mode", drive_mode_bitset_write.to_ulong());
-      XSLOG_DEBUG(
-        "ID: %d, write Drive_Mode [%s].",
-        motor_map[motor_name].motor_id, drive_mode_bitset_write.to_string().c_str());
-    } else if (drive_mode_bitset_read.test(2) && profile_type == profile::VELOCITY) {
-      // if the 2nd read bit was ON and profile_type is velocity, write new Drive_Mode
-      dxl_wb.itemWrite(
-        motor_map[motor_name].motor_id, "Drive_Mode", drive_mode_bitset_write.to_ulong());
-      XSLOG_DEBUG(
-        "ID: %d, write Drive_Mode [%s].",
-        motor_map[motor_name].motor_id, drive_mode_bitset_write.to_string().c_str());
+InterbotixDriverXS::InterbotixDriverXS(std::string filepath_motor_configs,
+                                       std::string filepath_mode_configs,
+                                       bool write_eeprom_on_startup, std::string logging_level) {
+    XSLOG_INFO("Using Interbotix X-Series Driver Version: 'v%d.%d.%d'.", VERSION_MAJOR,
+               VERSION_MINOR, VERSION_PATCH);
+    logging::set_level(logging_level);
+    XSLOG_INFO("Using logging level '%s'.", logging_level.c_str());
+    if (!retrieve_motor_configs(filepath_motor_configs, filepath_mode_configs)) {
+        throw std::runtime_error("Failed due to bad config.");
     }
 
-    if (mode == mode::POSITION || mode == mode::LINEAR_POSITION) {
-      // set position control mode if the mode is position or linear_position
-      // also set prof_acc and prof_vel
-      dxl_wb.setPositionControlMode(motor_map[motor_name].motor_id);
-      dxl_wb.itemWrite(
-        motor_map[motor_name].motor_id,
-        "Profile_Velocity",
-        profile_velocity);
-      dxl_wb.itemWrite(
-        motor_map[motor_name].motor_id,
-        "Profile_Acceleration",
-        profile_acceleration);
-      XSLOG_DEBUG(
-        "ID: %d, set mode position, prof_vel=%i, prof_acc=%i.",
-        motor_map[motor_name].motor_id, profile_velocity, profile_acceleration);
-    } else if (mode == mode::EXT_POSITION) {
-      // set ext_position control mode if the mode is ext_position
-      // also set prof_acc and prof_vel
-      dxl_wb.setExtendedPositionControlMode(
-        motor_map[motor_name].motor_id);
-      dxl_wb.itemWrite(
-        motor_map[motor_name].motor_id,
-        "Profile_Velocity",
-        profile_velocity);
-      dxl_wb.itemWrite(
-        motor_map[motor_name].motor_id,
-        "Profile_Acceleration",
-        profile_acceleration);
-      XSLOG_DEBUG(
-        "ID: %d, set mode ext_postition, pv=%i, pa=%i.",
-        motor_map[motor_name].motor_id, profile_velocity, profile_acceleration);
-    } else if (mode == mode::VELOCITY) {
-      // set velocity control mode if the mode is velocity
-      // also set prof_acc
-      dxl_wb.setVelocityControlMode(
-        motor_map[motor_name].motor_id);
-      dxl_wb.itemWrite(
-        motor_map[motor_name].motor_id,
-        "Profile_Acceleration",
-        profile_acceleration);
-      XSLOG_DEBUG(
-        "ID: %d, set mode velocity, prof_acc=%i.",
-        motor_map[motor_name].motor_id, profile_acceleration);
-    } else if (mode == mode::PWM) {
-      // set pwm control mode if the mode is pwm
-      dxl_wb.setPWMControlMode(
-        motor_map[motor_name].motor_id);
-      XSLOG_DEBUG(
-        "ID: %d, set mode pwm.",
-        motor_map[motor_name].motor_id);
-    } else if (mode == mode::CURRENT) {
-      // set current control mode if the mode is current
-      dxl_wb.setCurrentControlMode(
-        motor_map[motor_name].motor_id);
-      XSLOG_DEBUG(
-        "ID: %d, set mode current.",
-        motor_map[motor_name].motor_id);
-    } else if (mode == mode::CURRENT_BASED_POSITION) {
-      // set current_based_position control mode if the mode is current_based_position
-      dxl_wb.setCurrentBasedPositionControlMode(
-        motor_map[motor_name].motor_id);
-      XSLOG_DEBUG(
-        "ID: %d, set mode current_based_position.",
-        motor_map[motor_name].motor_id);
-    } else {
-      // mode was invalid
-      XSLOG_ERROR(
-        "Invalid command for argument 'mode' while setting the operating mode for the %s motor.",
-        motor_name.c_str());
-      continue;
-    }
-    // set the mode and profile_type of each servo in the motor map
-    motor_map[motor_name].mode = mode;
-    motor_map[motor_name].profile_type = profile_type;
-    motor_map[motor_name].profile_velocity = profile_velocity;
-    motor_map[motor_name].profile_acceleration = profile_acceleration;
-  }
-
-  // torque on all sister servos
-  for (auto const & joint_name : sister_map[name]) {
-    dxl_wb.torque(motor_map[joint_name].motor_id, true);
-    XSLOG_DEBUG(
-      "ID: %d, torqued on.",
-      motor_map[joint_name].motor_id);
-  }
-  return true;
-}
-
-bool InterbotixDriverXS::torque_enable(
-  const std::string cmd_type,
-  const std::string & name,
-  const bool & enable)
-{
-  if (cmd_type == cmd_type::GROUP && group_map.count(name) > 0) {
-    // group case
-    for (auto const & joint_name : get_group_info(name)->joint_names) {
-      // torque each servo in group
-      dxl_wb.torque(motor_map[joint_name].motor_id, enable);
+    if (!init_port()) {
+        throw std::runtime_error("Failed to open port.");
     }
 
-    // log torque action
-    if (enable) {
-      XSLOG_INFO("The '%s' group was torqued on.", name.c_str());
-    } else {
-      XSLOG_INFO("The '%s' group was torqued off.", name.c_str());
+    if (!ping_motors()) {
+        XSLOG_FATAL("Failed to find all motors. Shutting down...");
+        throw std::runtime_error("Failed to find all motors.");
     }
-  } else if (cmd_type == cmd_type::SINGLE && motor_map.count(name) > 0) {
-    // single case
-    // torque the single servo
-    dxl_wb.torque(motor_map[name].motor_id, enable);
 
-    // log torque action
-    if (enable) {
-      XSLOG_INFO("The '%s' joint was torqued on.", name.c_str());
-    } else {
-      XSLOG_INFO("The '%s' joint was torqued off.", name.c_str());
-    }
-  } else if ( // NOLINT https://github.com/ament/ament_lint/issues/158
-    (cmd_type == cmd_type::GROUP && group_map.count(name) == 0) ||
-    (cmd_type == cmd_type::SINGLE && motor_map.count(name) == 0))
-  {
-    // invalid name
-    XSLOG_ERROR(
-      "The '%s' joint/group does not exist. Was it added to the motor config file?",
-      name.c_str());
-    return false;
-  } else {
-    // inavlid cmd_type
-    XSLOG_ERROR(
-      "Invalid command for argument 'cmd_type' while torquing joints.");
-    return false;
-  }
-  return true;
-}
-
-bool InterbotixDriverXS::reboot_motors(
-  const std::string cmd_type,
-  const std::string & name,
-  const bool & enable,
-  const bool & smart_reboot)
-{
-  std::vector<std::string> joints_to_torque;
-  if (cmd_type == cmd_type::GROUP && group_map.count(name) > 0) {
-    // group case
-    for (auto const & joint_name : get_group_info(name)->joint_names) {
-      // iterate through each joint in group
-      if (smart_reboot) {
-        // if smart_reboot, find the servos that are in an error status
-        int32_t value = 0;
-        const char * log;
-        bool success = dxl_wb.itemRead(
-          motor_map[joint_name].motor_id,
-          "Hardware_Error_Status",
-          &value, &log);
-        if (success && value == 0) {
-          continue;
+    if (write_eeprom_on_startup) {
+        if (!load_motor_configs()) {
+            XSLOG_FATAL("Failed to write configurations to all motors. Shutting "
+                        "down...");
+            throw std::runtime_error("Failed to write configurations to all motors.");
         }
-      }
-      // reboot the servo
-      dxl_wb.reboot(motor_map[joint_name].motor_id);
-      XSLOG_INFO("The '%s' joint was rebooted.", joint_name.c_str());
-      if (enable) {
-        // add servo to joints_to_torque if enabled
-        joints_to_torque.push_back(joint_name);
-      }
+        XSLOG_WARN("Writing startup register values to EEPROM. This only needs to be "
+                   "done once on a robot if "
+                   "using a default motor config file, or after a motor config file "
+                   "has been modified. "
+                   "Can set `write_eeprom_on_startup` to false from now on.");
     }
-    if (!smart_reboot) {
-      XSLOG_INFO("The '%s' group was rebooted.", name.c_str());
+    else {
+        XSLOG_INFO("Skipping Load Configs.");
     }
-  } else if (cmd_type == cmd_type::SINGLE && motor_map.count(name) > 0) {
-    // single case
-    // reboot the single servo
-    dxl_wb.reboot(motor_map[name].motor_id);
-    XSLOG_INFO("The '%s' joint was rebooted.", name.c_str());
-    if (enable) {
-      // add servo to joints_to_torque if enabled
-      joints_to_torque.push_back(name);
-    }
-  } else if ( // NOLINT https://github.com/ament/ament_lint/issues/158
-    (cmd_type == cmd_type::GROUP && group_map.count(name) == 0) ||
-    (cmd_type == cmd_type::SINGLE && motor_map.count(name) == 0))
-  {
-    // invalid name
-    XSLOG_ERROR(
-      "The '%s' joint/group does not exist. Was it added to the motor config file?",
-      name.c_str());
-    return false;
-  } else {
-    // invalid cmd_type
-    XSLOG_ERROR(
-      "Invalid command for argument 'cmd_type' while rebooting motors.");
-    return false;
-  }
 
-  // torque servos in joints_to_torque and their sisters
-  for (const auto & joint_name : joints_to_torque) {
-    for (const auto & name : sister_map[joint_name]) {
-      torque_enable(cmd_type::SINGLE, name, true);
-    }
-  }
-  return true;
+    init_controlItems();
+    init_workbench_handlers();
+    init_operating_modes();
+    init_controlItems();
+    XSLOG_INFO("Interbotix X-Series Driver is up!");
 }
 
-template<typename T>
-bool InterbotixDriverXS::write_commands(
-  const std::string & name,
-  std::vector<T> commands_in)
-{
-  std::vector<float> commands(commands_in.begin(), commands_in.end());
-  if (commands.size() != get_group_info(name)->joint_num) {
-    XSLOG_ERROR(
-      "Number of commands (%ld) does not match the number of joints in group '%s' (%d). "
-      "Will not execute.",
-      commands.size(), name.c_str(), get_group_info(name)->joint_num);
-    return false;
-  }
-  const std::string mode = get_group_info(name)->mode;
-  std::vector<int32_t> dynamixel_commands(commands.size());
-  if (
-    (mode == mode::POSITION) ||
-    (mode == mode::EXT_POSITION) ||
-    (mode == mode::CURRENT_BASED_POSITION) ||
-    (mode == mode::LINEAR_POSITION))
-  {
-    // position commands case
-    for (size_t i{0}; i < commands.size(); i++) {
-      if (mode == mode::LINEAR_POSITION) {
-        // convert from linear position if necessary
-        commands.at(i) = convert_linear_position_to_radian(
-          get_group_info(name)->joint_names.at(i),
-          commands.at(i));
-      }
-      // translate from position to command value
-      dynamixel_commands[i] = dxl_wb.convertRadian2Value(
-        get_group_info(name)->joint_ids.at(i),
-        commands.at(i));
-      XSLOG_DEBUG(
-        "ID: %d, writing %s command %d.",
-        get_group_info(name)->joint_ids.at(i),
-        mode.c_str(),
-        dynamixel_commands[i]);
+bool InterbotixDriverXS::set_operating_modes(const std::string& cmd_type, const std::string& name,
+                                             const std::string& mode,
+                                             const std::string profile_type,
+                                             const int32_t profile_velocity,
+                                             const int32_t profile_acceleration) {
+    if (cmd_type == cmd_type::GROUP && group_map.count(name) > 0) {
+        // group case
+        for (const auto& joint_name : get_group_info(name)->joint_names) {
+            set_joint_operating_mode(joint_name, mode, profile_type, profile_velocity,
+                                     profile_acceleration);
+        }
+        get_group_info(name)->mode = mode;
+        get_group_info(name)->profile_type = profile_type;
+        get_group_info(name)->profile_velocity = profile_velocity;
+        get_group_info(name)->profile_acceleration = profile_acceleration;
+        XSLOG_INFO("The operating mode for the '%s' group was changed to '%s' with "
+                   "profile type '%s'.",
+                   name.c_str(), mode.c_str(), profile_type.c_str());
     }
-    // write position commands
-    dxl_wb.syncWrite(
-      SYNC_WRITE_HANDLER_FOR_GOAL_POSITION,
-      get_group_info(name)->joint_ids.data(),
-      get_group_info(name)->joint_num,
-      &dynamixel_commands[0],
-      1);
-  } else if (mode == mode::VELOCITY) {
-    // velocity commands case
-    for (size_t i{0}; i < commands.size(); i++) {
-      // translate from velocity to command value
-      dynamixel_commands[i] = dxl_wb.convertVelocity2Value(
-        get_group_info(name)->joint_ids.at(i),
-        commands.at(i));
-      XSLOG_DEBUG(
-        "ID: %d, writing %s command %d.",
-        get_group_info(name)->joint_ids.at(i),
-        mode.c_str(),
-        dynamixel_commands[i]);
+    else if (cmd_type == cmd_type::SINGLE && motor_map.count(name) > 0) {
+        // single case
+        set_joint_operating_mode(name, mode, profile_type, profile_velocity, profile_acceleration);
+        XSLOG_INFO("The operating mode for the '%s' joint was changed to '%s' with "
+                   "profile type '%s'.",
+                   name.c_str(), mode.c_str(), profile_type.c_str());
     }
-    // write velocity commands
-    dxl_wb.syncWrite(
-      SYNC_WRITE_HANDLER_FOR_GOAL_VELOCITY,
-      get_group_info(name)->joint_ids.data(),
-      get_group_info(name)->joint_num,
-      &dynamixel_commands[0],
-      1);
-  } else if (mode == mode::CURRENT) {
-    // velocity commands case
-    for (size_t i{0}; i < commands.size(); i++) {
-      // translate from current to command value
-      dynamixel_commands[i] = dxl_wb.convertCurrent2Value(commands.at(i));
-      XSLOG_DEBUG(
-        "ID: %d, writing %s command %d.",
-        get_group_info(name)->joint_ids.at(i),
-        mode.c_str(),
-        dynamixel_commands[i]);
+    else if (  // NOLINT https://github.com/ament/ament_lint/issues/158
+        (cmd_type == cmd_type::GROUP && group_map.count(name) == 0) ||
+        (cmd_type == cmd_type::SINGLE && motor_map.count(name) == 0)) {
+        // case where specified joint or group does not exist depending on
+        // cmd_type
+        XSLOG_ERROR("The '%s' joint/group does not exist. Was it added to the motor "
+                    "config file?",
+                    name.c_str());
+        return false;
     }
-    // write velocity commands
-    dxl_wb.syncWrite(
-      SYNC_WRITE_HANDLER_FOR_GOAL_CURRENT,
-      get_group_info(name)->joint_ids.data(),
-      get_group_info(name)->joint_num,
-      &dynamixel_commands[0],
-      1);
-  } else if (mode == mode::PWM) {
-    // pwm commands case, don't need to translate from pwm to value
-    for (size_t i{0}; i < commands.size(); i++) {
-      dynamixel_commands[i] = int32_t(commands.at(i));
-      XSLOG_DEBUG(
-        "ID: %d, writing %s command %d.",
-        get_group_info(name)->joint_ids.at(i),
-        mode.c_str(),
-        dynamixel_commands[i]);
+    else {
+        // case where cmd_type is invalid (i.e. not 'group' or 'single')
+        XSLOG_ERROR("Invalid command for argument 'cmd_type' while setting operating "
+                    "mode.");
+        return false;
     }
-    // write pwm commands
-    dxl_wb.syncWrite(
-      SYNC_WRITE_HANDLER_FOR_GOAL_PWM,
-      get_group_info(name)->joint_ids.data(),
-      get_group_info(name)->joint_num,
-      &dynamixel_commands[0],
-      1);
-  } else {
-    // invalid mode
-    XSLOG_ERROR(
-      "Invalid command for argument 'mode' while commanding joint group.");
-    return false;
-  }
-  return true;
+    return true;
 }
 
-bool InterbotixDriverXS::write_position_commands(
-  const std::string & name,
-  std::vector<float> commands,
-  bool blocking)
-{
-  std::string mode = group_map.at(name).mode;
-  if (mode != mode::POSITION) {
-    XSLOG_ERROR(
-      "Group '%s' is in %s mode not in position mode. Will not execute commands.",
-      name.c_str(), mode.c_str());
-    return false;
-  }
-
-  bool res = write_commands(name, commands);
-  if (blocking) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(group_map.at(name).profile_velocity));
-  }
-  return res;
-}
-
-bool InterbotixDriverXS::write_joint_command(
-  const std::string & name,
-  float command)
-{
-  const std::string mode = motor_map[name].mode;
-  if (
-    (mode == mode::POSITION) ||
-    (mode == mode::EXT_POSITION) ||
-    (mode == mode::CURRENT_BASED_POSITION) ||
-    (mode == mode::LINEAR_POSITION))
-  {
-    // position command case
-    if (mode == mode::LINEAR_POSITION) {
-      // convert from linear position if necessary
-      command = convert_linear_position_to_radian(name, command);
-    }
-    XSLOG_DEBUG(
-      "ID: %d, writing %s command %f.",
-      motor_map[name].motor_id, mode.c_str(), command);
-    // write position command
-    dxl_wb.goalPosition(motor_map[name].motor_id, command);
-  } else if (mode == mode::VELOCITY) {
-    // position velocity case
-    XSLOG_DEBUG(
-      "ID: %d, writing %s command %f.",
-      motor_map[name].motor_id, mode.c_str(), command);
-    // write velocity command
-    dxl_wb.goalVelocity(motor_map[name].motor_id, command);
-  } else if (mode == mode::CURRENT) {
-    // position current case
-    XSLOG_DEBUG(
-      "ID: %d, writing %s command %f.",
-      motor_map[name].motor_id, mode.c_str(), command);
-    // write current command
-    dxl_wb.itemWrite(
-      motor_map[name].motor_id, "Goal_Current", dxl_wb.convertCurrent2Value(command));
-  } else if (mode == mode::PWM) {
-    // pwm current case
-    XSLOG_DEBUG(
-      "ID: %d, writing %s command %f.",
-      motor_map[name].motor_id, mode.c_str(), command);
-    // write pwm command
-    dxl_wb.itemWrite(motor_map[name].motor_id, "Goal_PWM", int32_t(command));
-  } else {
-    // invalid mode
-    XSLOG_ERROR(
-      "Invalid command for argument 'mode' while commanding joint '%s'.", name.c_str());
-    return false;
-  }
-  return true;
-}
-
-bool InterbotixDriverXS::set_motor_pid_gains(
-  const std::string cmd_type,
-  const std::string & name,
-  const std::vector<int32_t> & gains)
-{
-  std::vector<std::string> names;
-  if (cmd_type == cmd_type::GROUP) {
-    // group case, get names from group map
-    names = get_group_info(name)->joint_names;
-  } else if (cmd_type == cmd_type::SINGLE) {
-    // single case, just use given name
-    names.push_back(name);
-  }
-
-  for (auto const & name : names) {
-    // write gains for each servo
-    uint8_t id = motor_map[name].motor_id;
-    XSLOG_DEBUG("ID: %d, writing gains:", motor_map[name].motor_id);
-    XSLOG_DEBUG("        Pos_P: %i", gains.at(0));
-    XSLOG_DEBUG("        Pos_I: %i", gains.at(1));
-    XSLOG_DEBUG("        Pos_D: %i", gains.at(2));
-    XSLOG_DEBUG("        FF_1: %i", gains.at(3));
-    XSLOG_DEBUG("        FF_2: %i", gains.at(4));
-    XSLOG_DEBUG("        Vel_P: %i", gains.at(5));
-    XSLOG_DEBUG("        Vel_I: %i", gains.at(6));
-    dxl_wb.itemWrite(id, "Position_P_Gain", gains.at(0));
-    dxl_wb.itemWrite(id, "Position_I_Gain", gains.at(1));
-    dxl_wb.itemWrite(id, "Position_D_Gain", gains.at(2));
-    dxl_wb.itemWrite(id, "Feedforward_1st_Gain", gains.at(3));
-    dxl_wb.itemWrite(id, "Feedforward_2nd_Gain", gains.at(4));
-    dxl_wb.itemWrite(id, "Velocity_P_Gain", gains.at(5));
-    dxl_wb.itemWrite(id, "Velocity_I_Gain", gains.at(6));
-  }
-  return true;
-}
-
-bool InterbotixDriverXS::set_motor_registers(
-  const std::string cmd_type,
-  const std::string & name,
-  const std::string & reg,
-  const int32_t & value)
-{
-  std::vector<std::string> names;
-  if (cmd_type == cmd_type::GROUP) {
-    // group case, get names from group map
-    names = get_group_info(name)->joint_names;
-  } else if (cmd_type == cmd_type::SINGLE) {
-    // single case, just use given name
-    names.push_back(name);
-  }
-
-  for (auto const & name : names) {
-    // write register for each servo
-    XSLOG_DEBUG(
-      "ID: %d, writing reg: %s, value: %d.",
-      motor_map[name].motor_id, reg.c_str(), value);
-    dxl_wb.itemWrite(motor_map[name].motor_id, reg.c_str(), value);
-  }
-  return true;
-}
-
-bool InterbotixDriverXS::get_motor_registers(
-  const std::string cmd_type,
-  const std::string & name,
-  const std::string & reg,
-  std::vector<int32_t> & values)
-{
-  std::vector<std::string> names;
-  if (cmd_type == cmd_type::GROUP) {
-    // group case, get names from group map
-    names = get_group_info(name)->joint_names;
-  } else if (cmd_type == cmd_type::SINGLE) {
-    // single case, just use given name
-    names.push_back(name);
-  }
-
-  // get info on the register that is going to be read from
-  const ControlItem * goal_reg = dxl_wb.getItemInfo(
-    motor_map.at(names.front()).motor_id, reg.c_str());
-  if (goal_reg == NULL) {
-    XSLOG_ERROR(
-      "Could not get '%s' Item Info. Did you spell the register name correctly?",
-      reg.c_str());
-    return false;
-  }
-
-  for (auto const & name : names) {
-    int32_t value = 0;
-    const char * log;
-    // read register for each servo and check result for success
-    if (!dxl_wb.itemRead(motor_map[name].motor_id, reg.c_str(), &value, &log)) {
-      XSLOG_ERROR("%s", log);
-      return false;
-    } else {
-      XSLOG_DEBUG(
-        "ID: %d, reading reg: '%s', value: %d.", motor_map[name].motor_id, reg.c_str(), value);
+bool InterbotixDriverXS::set_joint_operating_mode(const std::string& name, const std::string& mode,
+                                                  const std::string profile_type,
+                                                  const int32_t profile_velocity,
+                                                  const int32_t profile_acceleration) {
+    // torque off sister servos
+    for (const auto& joint_name : sister_map[name]) {
+        dxl_wb.torque(motor_map[joint_name].motor_id, false);
+        XSLOG_DEBUG("ID: %d, torqued off.", motor_map[joint_name].motor_id);
     }
 
-    // add register to values vector with type depending on data_length
-    if (goal_reg->data_length == 1) {
-      values.push_back((uint8_t)value);
-    } else if (goal_reg->data_length == 2) {
-      values.push_back((int16_t)value);
-    } else {
-      values.push_back(value);
+    for (const auto& motor_name : shadow_map[name]) {
+        int32_t drive_mode;
+        // read drive mode for each shadow
+        dxl_wb.itemRead(motor_map[motor_name].motor_id, "Drive_Mode", &drive_mode);
+        std::bitset<8> drive_mode_bitset_read = drive_mode, drive_mode_bitset_write = drive_mode;
+        XSLOG_DEBUG("ID: %d, read Drive_Mode [%s].", motor_map[motor_name].motor_id,
+                    drive_mode_bitset_read.to_string().c_str());
+        // The 2nd (0x04) bit of the Drive_Mode register sets Profile
+        // Configuration [0/false]: Velocity-based Profile: Create a Profile
+        // based on Velocity [1/true]: Time-based Profile: Create Profile based
+        // on Time
+        if (profile_type == profile::TIME) {
+            drive_mode_bitset_write.set(2);  // turn ON for time profile
+        }
+        else if (profile_type == profile::VELOCITY) {
+            drive_mode_bitset_write.reset(2);  // turn OFF for velocity profile
+        }
+        // if not correct, write the correct drive mode based on the profile
+        // type see
+        // https://emanual.robotis.com/docs/en/dxl/x/xm430-w350/#drive-mode for
+        // details
+        if (!drive_mode_bitset_read.test(2) && profile_type == profile::TIME) {
+            // if the 2nd read bit was OFF and profile_type is time, write new
+            // Drive_Mode
+            dxl_wb.itemWrite(motor_map[motor_name].motor_id, "Drive_Mode",
+                             drive_mode_bitset_write.to_ulong());
+            XSLOG_DEBUG("ID: %d, write Drive_Mode [%s].", motor_map[motor_name].motor_id,
+                        drive_mode_bitset_write.to_string().c_str());
+        }
+        else if (drive_mode_bitset_read.test(2) && profile_type == profile::VELOCITY) {
+            // if the 2nd read bit was ON and profile_type is velocity, write
+            // new Drive_Mode
+            dxl_wb.itemWrite(motor_map[motor_name].motor_id, "Drive_Mode",
+                             drive_mode_bitset_write.to_ulong());
+            XSLOG_DEBUG("ID: %d, write Drive_Mode [%s].", motor_map[motor_name].motor_id,
+                        drive_mode_bitset_write.to_string().c_str());
+        }
+
+        if (mode == mode::POSITION || mode == mode::LINEAR_POSITION) {
+            // set position control mode if the mode is position or
+            // linear_position also set prof_acc and prof_vel
+            dxl_wb.setPositionControlMode(motor_map[motor_name].motor_id);
+            dxl_wb.itemWrite(motor_map[motor_name].motor_id, "Profile_Velocity", profile_velocity);
+            dxl_wb.itemWrite(motor_map[motor_name].motor_id, "Profile_Acceleration",
+                             profile_acceleration);
+            XSLOG_DEBUG("ID: %d, set mode position, prof_vel=%i, prof_acc=%i.",
+                        motor_map[motor_name].motor_id, profile_velocity, profile_acceleration);
+        }
+        else if (mode == mode::EXT_POSITION) {
+            // set ext_position control mode if the mode is ext_position
+            // also set prof_acc and prof_vel
+            dxl_wb.setExtendedPositionControlMode(motor_map[motor_name].motor_id);
+            dxl_wb.itemWrite(motor_map[motor_name].motor_id, "Profile_Velocity", profile_velocity);
+            dxl_wb.itemWrite(motor_map[motor_name].motor_id, "Profile_Acceleration",
+                             profile_acceleration);
+            XSLOG_DEBUG("ID: %d, set mode ext_postition, pv=%i, pa=%i.",
+                        motor_map[motor_name].motor_id, profile_velocity, profile_acceleration);
+        }
+        else if (mode == mode::VELOCITY) {
+            // set velocity control mode if the mode is velocity
+            // also set prof_acc
+            dxl_wb.setVelocityControlMode(motor_map[motor_name].motor_id);
+            dxl_wb.itemWrite(motor_map[motor_name].motor_id, "Profile_Acceleration",
+                             profile_acceleration);
+            XSLOG_DEBUG("ID: %d, set mode velocity, prof_acc=%i.", motor_map[motor_name].motor_id,
+                        profile_acceleration);
+        }
+        else if (mode == mode::PWM) {
+            // set pwm control mode if the mode is pwm
+            dxl_wb.setPWMControlMode(motor_map[motor_name].motor_id);
+            XSLOG_DEBUG("ID: %d, set mode pwm.", motor_map[motor_name].motor_id);
+        }
+        else if (mode == mode::CURRENT) {
+            // set current control mode if the mode is current
+            dxl_wb.setCurrentControlMode(motor_map[motor_name].motor_id);
+            XSLOG_DEBUG("ID: %d, set mode current.", motor_map[motor_name].motor_id);
+        }
+        else if (mode == mode::CURRENT_BASED_POSITION) {
+            // set current_based_position control mode if the mode is
+            // current_based_position
+            dxl_wb.setCurrentBasedPositionControlMode(motor_map[motor_name].motor_id);
+            XSLOG_DEBUG("ID: %d, set mode current_based_position.", motor_map[motor_name].motor_id);
+        }
+        else {
+            // mode was invalid
+            XSLOG_ERROR("Invalid command for argument 'mode' while setting the "
+                        "operating mode for the %s motor.",
+                        motor_name.c_str());
+            continue;
+        }
+        // set the mode and profile_type of each servo in the motor map
+        motor_map[motor_name].mode = mode;
+        motor_map[motor_name].profile_type = profile_type;
+        motor_map[motor_name].profile_velocity = profile_velocity;
+        motor_map[motor_name].profile_acceleration = profile_acceleration;
     }
-  }
-  return true;
+
+    // torque on all sister servos
+    for (const auto& joint_name : sister_map[name]) {
+        dxl_wb.torque(motor_map[joint_name].motor_id, true);
+        XSLOG_DEBUG("ID: %d, torqued on.", motor_map[joint_name].motor_id);
+    }
+    return true;
 }
 
-bool InterbotixDriverXS::get_joint_states(
-  const std::string & name,
-  std::vector<float> * positions,
-  std::vector<float> * velocities,
-  std::vector<float> * effort)
-{
-  read_joint_states();
-  std::lock_guard<std::mutex> guard(_mutex_js);
-  for (const auto & joint_name : get_group_info(name)->joint_names) {
-    // iterate through each joint in group, reading pos, vel, and eff
-    if (positions) {
-      positions->push_back(robot_positions.at(get_js_index(joint_name)));
+bool InterbotixDriverXS::torque_enable(const std::string cmd_type, const std::string& name,
+                                       const bool& enable) {
+    if (cmd_type == cmd_type::GROUP && group_map.count(name) > 0) {
+        // group case
+        for (const auto& joint_name : get_group_info(name)->joint_names) {
+            // torque each servo in group
+            dxl_wb.torque(motor_map[joint_name].motor_id, enable);
+        }
+
+        // log torque action
+        if (enable) {
+            XSLOG_INFO("The '%s' group was torqued on.", name.c_str());
+        }
+        else {
+            XSLOG_INFO("The '%s' group was torqued off.", name.c_str());
+        }
     }
-    if (velocities) {
-      velocities->push_back(robot_velocities.at(get_js_index(joint_name)));
+    else if (cmd_type == cmd_type::SINGLE && motor_map.count(name) > 0) {
+        // single case
+        // torque the single servo
+        dxl_wb.torque(motor_map[name].motor_id, enable);
+
+        // log torque action
+        if (enable) {
+            XSLOG_INFO("The '%s' joint was torqued on.", name.c_str());
+        }
+        else {
+            XSLOG_INFO("The '%s' joint was torqued off.", name.c_str());
+        }
+    }
+    else if (  // NOLINT https://github.com/ament/ament_lint/issues/158
+        (cmd_type == cmd_type::GROUP && group_map.count(name) == 0) ||
+        (cmd_type == cmd_type::SINGLE && motor_map.count(name) == 0)) {
+        // invalid name
+        XSLOG_ERROR("The '%s' joint/group does not exist. Was it added to the motor "
+                    "config file?",
+                    name.c_str());
+        return false;
+    }
+    else {
+        // inavlid cmd_type
+        XSLOG_ERROR("Invalid command for argument 'cmd_type' while torquing joints.");
+        return false;
+    }
+    return true;
+}
+
+bool InterbotixDriverXS::reboot_motors(const std::string cmd_type, const std::string& name,
+                                       const bool& enable, const bool& smart_reboot) {
+    std::vector<std::string> joints_to_torque;
+    if (cmd_type == cmd_type::GROUP && group_map.count(name) > 0) {
+        // group case
+        for (const auto& joint_name : get_group_info(name)->joint_names) {
+            // iterate through each joint in group
+            if (smart_reboot) {
+                // if smart_reboot, find the servos that are in an error status
+                int32_t value = 0;
+                const char* log;
+                bool success = dxl_wb.itemRead(motor_map[joint_name].motor_id,
+                                               "Hardware_Error_Status", &value, &log);
+                if (success && value == 0) {
+                    continue;
+                }
+            }
+            // reboot the servo
+            dxl_wb.reboot(motor_map[joint_name].motor_id);
+            XSLOG_INFO("The '%s' joint was rebooted.", joint_name.c_str());
+            if (enable) {
+                // add servo to joints_to_torque if enabled
+                joints_to_torque.push_back(joint_name);
+            }
+        }
+        if (!smart_reboot) {
+            XSLOG_INFO("The '%s' group was rebooted.", name.c_str());
+        }
+    }
+    else if (cmd_type == cmd_type::SINGLE && motor_map.count(name) > 0) {
+        // single case
+        // reboot the single servo
+        dxl_wb.reboot(motor_map[name].motor_id);
+        XSLOG_INFO("The '%s' joint was rebooted.", name.c_str());
+        if (enable) {
+            // add servo to joints_to_torque if enabled
+            joints_to_torque.push_back(name);
+        }
+    }
+    else if (  // NOLINT https://github.com/ament/ament_lint/issues/158
+        (cmd_type == cmd_type::GROUP && group_map.count(name) == 0) ||
+        (cmd_type == cmd_type::SINGLE && motor_map.count(name) == 0)) {
+        // invalid name
+        XSLOG_ERROR("The '%s' joint/group does not exist. Was it added to the motor "
+                    "config file?",
+                    name.c_str());
+        return false;
+    }
+    else {
+        // invalid cmd_type
+        XSLOG_ERROR("Invalid command for argument 'cmd_type' while rebooting motors.");
+        return false;
+    }
+
+    // torque servos in joints_to_torque and their sisters
+    for (const auto& joint_name : joints_to_torque) {
+        for (const auto& name : sister_map[joint_name]) {
+            torque_enable(cmd_type::SINGLE, name, true);
+        }
+    }
+    return true;
+}
+
+template <typename T>
+bool InterbotixDriverXS::write_commands(const std::string& name, std::vector<T> commands_in) {
+    std::vector<float> commands(commands_in.begin(), commands_in.end());
+    if (commands.size() != get_group_info(name)->joint_num) {
+        XSLOG_ERROR("Number of commands (%ld) does not match the number of joints in "
+                    "group '%s' (%d). "
+                    "Will not execute.",
+                    commands.size(), name.c_str(), get_group_info(name)->joint_num);
+        return false;
+    }
+    const std::string mode = get_group_info(name)->mode;
+    std::vector<int32_t> dynamixel_commands(commands.size());
+    if ((mode == mode::POSITION) || (mode == mode::EXT_POSITION) ||
+        (mode == mode::CURRENT_BASED_POSITION) || (mode == mode::LINEAR_POSITION)) {
+        // position commands case
+        for (size_t i{0}; i < commands.size(); i++) {
+            if (mode == mode::LINEAR_POSITION) {
+                // convert from linear position if necessary
+                commands.at(i) = convert_linear_position_to_radian(
+                    get_group_info(name)->joint_names.at(i), commands.at(i));
+            }
+            // translate from position to command value
+            dynamixel_commands[i] =
+                dxl_wb.convertRadian2Value(get_group_info(name)->joint_ids.at(i), commands.at(i));
+            XSLOG_DEBUG("ID: %d, writing %s command %d.", get_group_info(name)->joint_ids.at(i),
+                        mode.c_str(), dynamixel_commands[i]);
+        }
+        // write position commands
+        dxl_wb.syncWrite(SYNC_WRITE_HANDLER_FOR_GOAL_POSITION,
+                         get_group_info(name)->joint_ids.data(), get_group_info(name)->joint_num,
+                         &dynamixel_commands[0], 1);
+    }
+    else if (mode == mode::VELOCITY) {
+        // velocity commands case
+        for (size_t i{0}; i < commands.size(); i++) {
+            // translate from velocity to command value
+            dynamixel_commands[i] =
+                dxl_wb.convertVelocity2Value(get_group_info(name)->joint_ids.at(i), commands.at(i));
+            XSLOG_DEBUG("ID: %d, writing %s command %d.", get_group_info(name)->joint_ids.at(i),
+                        mode.c_str(), dynamixel_commands[i]);
+        }
+        // write velocity commands
+        dxl_wb.syncWrite(SYNC_WRITE_HANDLER_FOR_GOAL_VELOCITY,
+                         get_group_info(name)->joint_ids.data(), get_group_info(name)->joint_num,
+                         &dynamixel_commands[0], 1);
+    }
+    else if (mode == mode::CURRENT) {
+        // velocity commands case
+        for (size_t i{0}; i < commands.size(); i++) {
+            // translate from current to command value
+            dynamixel_commands[i] = dxl_wb.convertCurrent2Value(commands.at(i));
+            XSLOG_DEBUG("ID: %d, writing %s command %d.", get_group_info(name)->joint_ids.at(i),
+                        mode.c_str(), dynamixel_commands[i]);
+        }
+        // write velocity commands
+        dxl_wb.syncWrite(SYNC_WRITE_HANDLER_FOR_GOAL_CURRENT,
+                         get_group_info(name)->joint_ids.data(), get_group_info(name)->joint_num,
+                         &dynamixel_commands[0], 1);
+    }
+    else if (mode == mode::PWM) {
+        // pwm commands case, don't need to translate from pwm to value
+        for (size_t i{0}; i < commands.size(); i++) {
+            dynamixel_commands[i] = int32_t(commands.at(i));
+            XSLOG_DEBUG("ID: %d, writing %s command %d.", get_group_info(name)->joint_ids.at(i),
+                        mode.c_str(), dynamixel_commands[i]);
+        }
+        // write pwm commands
+        dxl_wb.syncWrite(SYNC_WRITE_HANDLER_FOR_GOAL_PWM, get_group_info(name)->joint_ids.data(),
+                         get_group_info(name)->joint_num, &dynamixel_commands[0], 1);
+    }
+    else {
+        // invalid mode
+        XSLOG_ERROR("Invalid command for argument 'mode' while commanding joint "
+                    "group.");
+        return false;
+    }
+    return true;
+}
+
+bool InterbotixDriverXS::write_position_commands(const std::string& name,
+                                                 std::vector<float> commands, bool blocking) {
+    std::string mode = group_map.at(name).mode;
+    if (mode != mode::POSITION) {
+        XSLOG_ERROR("Group '%s' is in %s mode not in position mode. Will not execute "
+                    "commands.",
+                    name.c_str(), mode.c_str());
+        return false;
+    }
+
+    bool res = write_commands(name, commands);
+    if (blocking) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(group_map.at(name).profile_velocity));
+    }
+    return res;
+}
+
+bool InterbotixDriverXS::write_joint_command(const std::string& name, float command) {
+    const std::string mode = motor_map[name].mode;
+    if ((mode == mode::POSITION) || (mode == mode::EXT_POSITION) ||
+        (mode == mode::CURRENT_BASED_POSITION) || (mode == mode::LINEAR_POSITION)) {
+        // position command case
+        if (mode == mode::LINEAR_POSITION) {
+            // convert from linear position if necessary
+            command = convert_linear_position_to_radian(name, command);
+        }
+        XSLOG_DEBUG("ID: %d, writing %s command %f.", motor_map[name].motor_id, mode.c_str(),
+                    command);
+        // write position command
+        dxl_wb.goalPosition(motor_map[name].motor_id, command);
+    }
+    else if (mode == mode::VELOCITY) {
+        // position velocity case
+        XSLOG_DEBUG("ID: %d, writing %s command %f.", motor_map[name].motor_id, mode.c_str(),
+                    command);
+        // write velocity command
+        dxl_wb.goalVelocity(motor_map[name].motor_id, command);
+    }
+    else if (mode == mode::CURRENT) {
+        // position current case
+        XSLOG_DEBUG("ID: %d, writing %s command %f.", motor_map[name].motor_id, mode.c_str(),
+                    command);
+        // write current command
+        dxl_wb.itemWrite(motor_map[name].motor_id, "Goal_Current",
+                         dxl_wb.convertCurrent2Value(command));
+    }
+    else if (mode == mode::PWM) {
+        // pwm current case
+        XSLOG_DEBUG("ID: %d, writing %s command %f.", motor_map[name].motor_id, mode.c_str(),
+                    command);
+        // write pwm command
+        dxl_wb.itemWrite(motor_map[name].motor_id, "Goal_PWM", int32_t(command));
+    }
+    else {
+        // invalid mode
+        XSLOG_ERROR("Invalid command for argument 'mode' while commanding joint '%s'.",
+                    name.c_str());
+        return false;
+    }
+    return true;
+}
+
+bool InterbotixDriverXS::set_motor_pid_gains(const std::string cmd_type, const std::string& name,
+                                             const std::vector<int32_t>& gains) {
+    std::vector<std::string> names;
+    if (cmd_type == cmd_type::GROUP) {
+        // group case, get names from group map
+        names = get_group_info(name)->joint_names;
+    }
+    else if (cmd_type == cmd_type::SINGLE) {
+        // single case, just use given name
+        names.push_back(name);
+    }
+
+    for (const auto& name : names) {
+        // write gains for each servo
+        uint8_t id = motor_map[name].motor_id;
+        XSLOG_DEBUG("ID: %d, writing gains:", motor_map[name].motor_id);
+        XSLOG_DEBUG("        Pos_P: %i", gains.at(0));
+        XSLOG_DEBUG("        Pos_I: %i", gains.at(1));
+        XSLOG_DEBUG("        Pos_D: %i", gains.at(2));
+        XSLOG_DEBUG("        FF_1: %i", gains.at(3));
+        XSLOG_DEBUG("        FF_2: %i", gains.at(4));
+        XSLOG_DEBUG("        Vel_P: %i", gains.at(5));
+        XSLOG_DEBUG("        Vel_I: %i", gains.at(6));
+        dxl_wb.itemWrite(id, "Position_P_Gain", gains.at(0));
+        dxl_wb.itemWrite(id, "Position_I_Gain", gains.at(1));
+        dxl_wb.itemWrite(id, "Position_D_Gain", gains.at(2));
+        dxl_wb.itemWrite(id, "Feedforward_1st_Gain", gains.at(3));
+        dxl_wb.itemWrite(id, "Feedforward_2nd_Gain", gains.at(4));
+        dxl_wb.itemWrite(id, "Velocity_P_Gain", gains.at(5));
+        dxl_wb.itemWrite(id, "Velocity_I_Gain", gains.at(6));
+    }
+    return true;
+}
+
+bool InterbotixDriverXS::set_motor_registers(const std::string cmd_type, const std::string& name,
+                                             const std::string& reg, const int32_t& value) {
+    std::vector<std::string> names;
+    if (cmd_type == cmd_type::GROUP) {
+        // group case, get names from group map
+        names = get_group_info(name)->joint_names;
+    }
+    else if (cmd_type == cmd_type::SINGLE) {
+        // single case, just use given name
+        names.push_back(name);
+    }
+
+    for (const auto& name : names) {
+        // write register for each servo
+        XSLOG_DEBUG("ID: %d, writing reg: %s, value: %d.", motor_map[name].motor_id, reg.c_str(),
+                    value);
+        dxl_wb.itemWrite(motor_map[name].motor_id, reg.c_str(), value);
+    }
+    return true;
+}
+
+bool InterbotixDriverXS::get_motor_registers(const std::string cmd_type, const std::string& name,
+                                             const std::string& reg, std::vector<int32_t>& values) {
+    std::vector<std::string> names;
+    if (cmd_type == cmd_type::GROUP) {
+        // group case, get names from group map
+        names = get_group_info(name)->joint_names;
+    }
+    else if (cmd_type == cmd_type::SINGLE) {
+        // single case, just use given name
+        names.push_back(name);
+    }
+
+    // get info on the register that is going to be read from
+    const ControlItem* goal_reg =
+        dxl_wb.getItemInfo(motor_map.at(names.front()).motor_id, reg.c_str());
+    if (goal_reg == NULL) {
+        XSLOG_ERROR("Could not get '%s' Item Info. Did you spell the register name "
+                    "correctly?",
+                    reg.c_str());
+        return false;
+    }
+
+    for (const auto& name : names) {
+        int32_t value = 0;
+        const char* log;
+        // read register for each servo and check result for success
+        if (!dxl_wb.itemRead(motor_map[name].motor_id, reg.c_str(), &value, &log)) {
+            XSLOG_ERROR("%s", log);
+            return false;
+        }
+        else {
+            XSLOG_DEBUG("ID: %d, reading reg: '%s', value: %d.", motor_map[name].motor_id,
+                        reg.c_str(), value);
+        }
+
+        // add register to values vector with type depending on data_length
+        if (goal_reg->data_length == 1) {
+            values.push_back((uint8_t)value);
+        }
+        else if (goal_reg->data_length == 2) {
+            values.push_back((int16_t)value);
+        }
+        else {
+            values.push_back(value);
+        }
+    }
+    return true;
+}
+
+bool InterbotixDriverXS::get_joint_states(const std::string& name, std::vector<float>* positions,
+                                          std::vector<float>* velocities,
+                                          std::vector<float>* effort) {
+    read_joint_states();
+    std::lock_guard<std::mutex> guard(_mutex_js);
+    for (const auto& joint_name : get_group_info(name)->joint_names) {
+        // iterate through each joint in group, reading pos, vel, and eff
+        if (positions) {
+            positions->push_back(robot_positions.at(get_js_index(joint_name)));
+        }
+        if (velocities) {
+            velocities->push_back(robot_velocities.at(get_js_index(joint_name)));
+        }
+        if (effort) {
+            effort->push_back(robot_efforts.at(get_js_index(joint_name)));
+        }
+    }
+    return true;
+}
+
+bool InterbotixDriverXS::get_joint_states(const std::string& name, std::vector<double>* positions,
+                                          std::vector<double>* velocities,
+                                          std::vector<double>* effort) {
+    read_joint_states();
+    std::lock_guard<std::mutex> guard(_mutex_js);
+    for (const auto& joint_name : get_group_info(name)->joint_names) {
+        // iterate through each joint in group, reading pos, vel, and eff
+        if (positions) {
+            positions->push_back(robot_positions.at(get_js_index(joint_name)));
+        }
+        if (velocities) {
+            velocities->push_back(robot_velocities.at(get_js_index(joint_name)));
+        }
+        if (effort) {
+            effort->push_back(robot_efforts.at(get_js_index(joint_name)));
+        }
+    }
+    return true;
+}
+
+bool InterbotixDriverXS::get_joint_state(const std::string& name, float* position, float* velocity,
+                                         float* effort) {
+    read_joint_states();
+    std::lock_guard<std::mutex> guard(_mutex_js);
+    // read pos, vel, and eff for specified joint
+    if (position) {
+        *position = robot_positions.at(get_js_index(name));
+    }
+    if (velocity) {
+        *velocity = robot_velocities.at(get_js_index(name));
     }
     if (effort) {
-      effort->push_back(robot_efforts.at(get_js_index(joint_name)));
+        *effort = robot_efforts.at(get_js_index(name));
     }
-  }
-  return true;
+    return true;
 }
 
-bool InterbotixDriverXS::get_joint_states(
-  const std::string & name,
-  std::vector<double> * positions,
-  std::vector<double> * velocities,
-  std::vector<double> * effort)
-{
-  read_joint_states();
-  std::lock_guard<std::mutex> guard(_mutex_js);
-  for (const auto & joint_name : get_group_info(name)->joint_names) {
-    // iterate through each joint in group, reading pos, vel, and eff
-    if (positions) {
-      positions->push_back(robot_positions.at(get_js_index(joint_name)));
-    }
-    if (velocities) {
-      velocities->push_back(robot_velocities.at(get_js_index(joint_name)));
-    }
-    if (effort) {
-      effort->push_back(robot_efforts.at(get_js_index(joint_name)));
-    }
-  }
-  return true;
+float InterbotixDriverXS::convert_linear_position_to_radian(const std::string& name,
+                                                            const float& linear_position) {
+    float half_dist = linear_position / 2.0;
+    float arm_length = gripper_map[name].arm_length;
+    float horn_radius = gripper_map[name].horn_radius;
+
+    // (pi / 2) - acos(horn_rad^2 + (pos / 2)^2 - arm_length^2) / (2 * horn_rad
+    // * (pos / 2))
+    return 3.14159 / 2.0 - acos((pow(horn_radius, 2) + pow(half_dist, 2) - pow(arm_length, 2)) /
+                                (2 * horn_radius * half_dist));
 }
 
-bool InterbotixDriverXS::get_joint_state(
-  const std::string & name,
-  float * position,
-  float * velocity,
-  float * effort)
-{
-  read_joint_states();
-  std::lock_guard<std::mutex> guard(_mutex_js);
-  // read pos, vel, and eff for specified joint
-  if (position) {
-    *position = robot_positions.at(get_js_index(name));
-  }
-  if (velocity) {
-    *velocity = robot_velocities.at(get_js_index(name));
-  }
-  if (effort) {
-    *effort = robot_efforts.at(get_js_index(name));
-  }
-  return true;
+float InterbotixDriverXS::convert_angular_position_to_linear(const std::string& name,
+                                                             const float& angular_position) {
+    float arm_length = gripper_map[name].arm_length;
+    float horn_radius = gripper_map[name].horn_radius;
+    float a1 = horn_radius * sin(angular_position);
+    float c = sqrt(pow(horn_radius, 2) - pow(a1, 2));
+    float a2 = sqrt(pow(arm_length, 2) - pow(c, 2));
+    return a1 + a2;
 }
 
-float InterbotixDriverXS::convert_linear_position_to_radian(
-  const std::string & name,
-  const float & linear_position)
-{
-  float half_dist = linear_position / 2.0;
-  float arm_length = gripper_map[name].arm_length;
-  float horn_radius = gripper_map[name].horn_radius;
+bool InterbotixDriverXS::retrieve_motor_configs(std::string filepath_motor_configs,
+                                                std::string filepath_mode_configs) {
+    // read motor_configs param
+    try {
+        // try to load motor_configs yaml file
+        motor_configs = YAML::LoadFile(filepath_motor_configs.c_str());
+    }
+    catch (YAML::BadFile& error) {
+        // if file is not found or a bad format, shut down
+        XSLOG_FATAL("Motor Config file was not found or has a bad format. Shutting "
+                    "down...");
+        XSLOG_FATAL("YAML Error: '%s'", error.what());
+        return false;
+    }
 
-  // (pi / 2) - acos(horn_rad^2 + (pos / 2)^2 - arm_length^2) / (2 * horn_rad * (pos / 2))
-  return 3.14159 / 2.0 - \
-         acos(
-    (pow(horn_radius, 2) + \
-    pow(half_dist, 2) - \
-    pow(arm_length, 2)) / (2 * horn_radius * half_dist));
+    if (motor_configs.IsNull()) {
+        // if motor_configs is not found or empty, shut down
+        XSLOG_FATAL("Motor Config file was not found. Shutting down...");
+        return false;
+    }
+
+    // read mode_configs param
+    try {
+        // try to load mode_configs yaml file
+        mode_configs = YAML::LoadFile(filepath_mode_configs.c_str());
+        XSLOG_INFO("Loaded mode configs from '%s'.", filepath_mode_configs.c_str());
+    }
+    catch (YAML::BadFile& error) {
+        // if file is not found or a bad format, shut down
+        XSLOG_FATAL("Mode Config file was not found or has a bad format. Shutting "
+                    "down...");
+        XSLOG_FATAL("YAML Error: '%s'", error.what());
+        return false;
+    }
+
+    if (mode_configs.IsNull()) {
+        // if mode_configs is not found or empty, use defaults
+        XSLOG_WARN("Mode Config file is empty. Will use defaults.");
+    }
+
+    // use specified or default port
+    port = motor_configs["port"].as<std::string>(DEFAULT_PORT);
+    if (mode_configs["port"]) {
+        port = mode_configs["port"].as<std::string>(DEFAULT_PORT);
+    }
+
+    // create all_motors node from 'motors'
+    YAML::Node all_motors = motor_configs["motors"];
+    for (YAML::const_iterator motor_itr = all_motors.begin(); motor_itr != all_motors.end();
+         motor_itr++) {
+        // iterate through each motor in all_motors node
+        // get motor name
+        std::string motor_name = motor_itr->first.as<std::string>();
+        // create single_motor node from the motor_name
+        YAML::Node single_motor = all_motors[motor_name];
+        // extract ID from node
+        uint8_t id = (uint8_t)single_motor["ID"].as<int32_t>();
+        // add the motor to the motor_map with it's ID, pos as the default
+        // opmode, vel as default
+        //  profile
+        motor_map.insert({motor_name, {id, mode::POSITION, profile::VELOCITY}});
+        for (YAML::const_iterator info_itr = single_motor.begin(); info_itr != single_motor.end();
+             info_itr++) {
+            // iterate through the single_motor node
+            // save all registers that are not ID or Baud_Rate
+            std::string reg = info_itr->first.as<std::string>();
+            if (reg != "ID" && reg != "Baud_Rate") {
+                int32_t value = info_itr->second.as<int32_t>();
+                MotorRegVal motor_info = {id, reg, value};
+                motor_info_vec.push_back(motor_info);
+            }
+        }
+    }
+
+    // create all_grippers node from 'grippers'
+    YAML::Node all_grippers = motor_configs["grippers"];
+    for (YAML::const_iterator gripper_itr = all_grippers.begin(); gripper_itr != all_grippers.end();
+         gripper_itr++) {
+        // iterate through each gripper in all_grippers node
+        // get gripper name
+        std::string gripper_name = gripper_itr->first.as<std::string>();
+        // create single_gripper node from the gripper_name
+        YAML::Node single_gripper = all_grippers[gripper_name];
+        // initialize a Gripper struct to save the info about this gripper
+        Gripper gripper;
+        // load all info from the single_gripper node into the Griper struct,
+        // substituting the default
+        //  values if not given the value
+        gripper.horn_radius = single_gripper["horn_radius"].as<float>(0.014);
+        gripper.arm_length = single_gripper["arm_length"].as<float>(0.024);
+        gripper.left_finger = single_gripper["left_finger"].as<std::string>("left_finger");
+        gripper.right_finger = single_gripper["right_finger"].as<std::string>("right_finger");
+        gripper_map.insert({gripper_name, gripper});
+    }
+
+    // create joint_order node from 'joint_order'
+    YAML::Node joint_order = motor_configs["joint_order"];
+    // create sleep_positions node from 'sleep_positions'
+    YAML::Node sleep_positions = motor_configs["sleep_positions"];
+    // create JointGroup struct for all_joints - contains all joints in robot
+    JointGroup all_joints;
+    all_joints.joint_num = (uint8_t)joint_order.size();
+    all_joints.mode = mode::POSITION;
+    all_joints.profile_type = profile::VELOCITY;
+    all_joints.profile_velocity = DEFAULT_PROF_VEL;
+    all_joints.profile_acceleration = DEFAULT_PROF_ACC;
+    for (size_t i{0}; i < joint_order.size(); i++) {
+        // iterate through each joint in joint_order list
+        // save each joint ID and name
+        std::string joint_name = joint_order[i].as<std::string>();
+        all_joints.joint_names.push_back(joint_name);
+        all_joints.joint_ids.push_back(motor_map[joint_name].motor_id);
+        // add this joint's index to the js_index_map
+        js_index_map.insert({joint_name, i});
+        // add any shadows
+        shadow_map.insert({joint_name, {joint_name}});
+        // add any sisters
+        sister_map.insert({joint_name, {joint_name}});
+        // add the sleep position of this joint, defaults to 0 if not specified
+        sleep_map.insert({joint_name, sleep_positions[i].as<float>(0)});
+        // if this joint is a gripper, add it to the gripper_name
+        if (gripper_map.count(joint_name) > 0) {
+            gripper_map[joint_name].js_index = i;
+            gripper_order.push_back(joint_name);
+        }
+    }
+
+    // append the left and right finger to the gripper_map
+    for (const auto& name : gripper_order) {
+        js_index_map.insert({gripper_map[name].left_finger, js_index_map.size()});
+        js_index_map.insert({gripper_map[name].right_finger, js_index_map.size()});
+    }
+
+    // all the all_joints JointGroup to the group_map
+    group_map.insert({"all", all_joints});
+    // create a pointer from the group_map's all group reference
+    all_ptr = &group_map.at("all");
+
+    // create all_shadows node from 'shadows'
+    YAML::Node all_shadows = motor_configs["shadows"];
+    for (YAML::const_iterator master_itr = all_shadows.begin(); master_itr != all_shadows.end();
+         master_itr++) {
+        // iterate through each shadow servo's master in all_shadows node
+        std::string master_name = master_itr->first.as<std::string>();
+        YAML::Node master = all_shadows[master_name];
+        YAML::Node shadow_list = master["shadow_list"];
+        for (size_t i{0}; i < shadow_list.size(); i++) {
+            shadow_map[master_name].push_back(shadow_list[i].as<std::string>());
+        }
+    }
+
+    // create all_sisters node from 'sisters'
+    YAML::Node all_sisters = motor_configs["sisters"];
+    for (YAML::const_iterator sister_itr = all_sisters.begin(); sister_itr != all_sisters.end();
+         sister_itr++) {
+        // iterate through each sister servo in all_sisters node
+        // save each 2-in-1 servo to the sister_map
+        std::string sister_one = sister_itr->first.as<std::string>();
+        std::string sister_two = sister_itr->second.as<std::string>();
+        sister_map[sister_one].push_back(sister_two);
+        sister_map[sister_two].push_back(sister_one);
+    }
+
+    // create all_groups node from 'groups'
+    YAML::Node all_groups = motor_configs["groups"];
+    for (YAML::const_iterator group_itr = all_groups.begin(); group_itr != all_groups.end();
+         group_itr++) {
+        // iterate through each sister servo in all_sisters node
+        // get the name of the group
+        std::string name = group_itr->first.as<std::string>();
+        // get the list of joints in the group from the all_group map
+        YAML::Node joint_list = all_groups[name];
+        // create a JointGroup for this group
+        JointGroup group;
+        // the number of joints in this group is the size of the list of joints
+        group.joint_num = (uint8_t)joint_list.size();
+        for (size_t i{0}; i < joint_list.size(); i++) {
+            // add each joint's name and id to the JointGroup
+            std::string joint_name = joint_list[i].as<std::string>();
+            group.joint_names.push_back(joint_name);
+            group.joint_ids.push_back(motor_map[joint_name].motor_id);
+        }
+        // add the JointGroup and its name to the group_map
+        group_map.insert({name, group});
+    }
+
+    XSLOG_INFO("Loaded motor configs from '%s'.", filepath_motor_configs.c_str());
+    return true;
 }
 
-float InterbotixDriverXS::convert_angular_position_to_linear(
-  const std::string & name,
-  const float & angular_position)
-{
-  float arm_length = gripper_map[name].arm_length;
-  float horn_radius = gripper_map[name].horn_radius;
-  float a1 = horn_radius * sin(angular_position);
-  float c = sqrt(pow(horn_radius, 2) - pow(a1, 2));
-  float a2 = sqrt(pow(arm_length, 2) - pow(c, 2));
-  return a1 + a2;
+bool InterbotixDriverXS::init_port() {
+    // try to connect to the specified port at the default baudrate
+    if (!dxl_wb.init(port.c_str(), DEFAULT_BAUDRATE)) {
+        // if the connection fails, shut down
+        XSLOG_FATAL("Failed to open port at '%s'. Shutting down...", port.c_str());
+        return false;
+    }
+    return true;
 }
 
-bool InterbotixDriverXS::retrieve_motor_configs(
-  std::string filepath_motor_configs,
-  std::string filepath_mode_configs)
-{
-  // read motor_configs param
-  try {
-    // try to load motor_configs yaml file
-    motor_configs = YAML::LoadFile(filepath_motor_configs.c_str());
-  } catch (YAML::BadFile & error) {
-    // if file is not found or a bad format, shut down
-    XSLOG_FATAL("Motor Config file was not found or has a bad format. Shutting down...");
-    XSLOG_FATAL("YAML Error: '%s'", error.what());
-    return false;
-  }
-
-  if (motor_configs.IsNull()) {
-    // if motor_configs is not found or empty, shut down
-    XSLOG_FATAL("Motor Config file was not found. Shutting down...");
-    return false;
-  }
-
-  // read mode_configs param
-  try {
-    // try to load mode_configs yaml file
-    mode_configs = YAML::LoadFile(filepath_mode_configs.c_str());
-    XSLOG_INFO(
-      "Loaded mode configs from '%s'.",
-      filepath_mode_configs.c_str());
-  } catch (YAML::BadFile & error) {
-    // if file is not found or a bad format, shut down
-    XSLOG_FATAL(
-      "Mode Config file was not found or has a bad format. Shutting down...");
-    XSLOG_FATAL(
-      "YAML Error: '%s'",
-      error.what());
-    return false;
-  }
-
-  if (mode_configs.IsNull()) {
-    // if mode_configs is not found or empty, use defaults
-    XSLOG_WARN("Mode Config file is empty. Will use defaults.");
-  }
-
-  // use specified or default port
-  port = motor_configs["port"].as<std::string>(DEFAULT_PORT);
-  if (mode_configs["port"]) {
-    port = mode_configs["port"].as<std::string>(DEFAULT_PORT);
-  }
-
-  // create all_motors node from 'motors'
-  YAML::Node all_motors = motor_configs["motors"];
-  for (
-    YAML::const_iterator motor_itr = all_motors.begin();
-    motor_itr != all_motors.end();
-    motor_itr++)
-  {
-    // iterate through each motor in all_motors node
-    // get motor name
-    std::string motor_name = motor_itr->first.as<std::string>();
-    // create single_motor node from the motor_name
-    YAML::Node single_motor = all_motors[motor_name];
-    // extract ID from node
-    uint8_t id = (uint8_t)single_motor["ID"].as<int32_t>();
-    // add the motor to the motor_map with it's ID, pos as the default opmode, vel as default
-    //  profile
-    motor_map.insert({motor_name, {id, mode::POSITION, profile::VELOCITY}});
-    for (
-      YAML::const_iterator info_itr = single_motor.begin();
-      info_itr != single_motor.end();
-      info_itr++)
-    {
-      // iterate through the single_motor node
-      // save all registers that are not ID or Baud_Rate
-      std::string reg = info_itr->first.as<std::string>();
-      if (reg != "ID" && reg != "Baud_Rate") {
-        int32_t value = info_itr->second.as<int32_t>();
-        MotorRegVal motor_info = {id, reg, value};
-        motor_info_vec.push_back(motor_info);
-      }
+bool InterbotixDriverXS::ping_motors() {
+    // result is true by default, if can't find motor, set this to false
+    bool found_all_motors = true;
+    const char* log;
+    for (size_t cntr_ping_motors = 0; cntr_ping_motors < 3; cntr_ping_motors++) {
+        XSLOG_INFO("Pinging all motors specified in the motor_config file. (Attempt "
+                   "%ld/3)",
+                   cntr_ping_motors + 1);
+        // iterate through each servo in the motor_map
+        for (const auto& [motor_name, motor_state] : motor_map) {
+            // try to ping the servo
+            if (!dxl_wb.ping(motor_state.motor_id, &log)) {
+                // if any ping is unsuccessful, shut down
+                XSLOG_ERROR("\tCan't find DYNAMIXEL ID: %2.d, Joint Name: '%s':\n\t\t  "
+                            "'%s'",
+                            motor_state.motor_id, motor_name.c_str(), log);
+                found_all_motors = false;
+            }
+            else {
+                XSLOG_INFO("\tFound DYNAMIXEL ID: %2.d, Model: '%s', Joint Name: "
+                           "'%s'.",
+                           motor_state.motor_id, dxl_wb.getModelName(motor_state.motor_id),
+                           motor_name.c_str());
+            }
+            // untorque each pinged servo, need to write data to the EEPROM
+            dxl_wb.torque(motor_state.motor_id, false);
+        }
+        if (found_all_motors) {
+            return found_all_motors;
+        }
     }
-  }
-
-  // create all_grippers node from 'grippers'
-  YAML::Node all_grippers = motor_configs["grippers"];
-  for (
-    YAML::const_iterator gripper_itr = all_grippers.begin();
-    gripper_itr != all_grippers.end();
-    gripper_itr++)
-  {
-    // iterate through each gripper in all_grippers node
-    // get gripper name
-    std::string gripper_name = gripper_itr->first.as<std::string>();
-    // create single_gripper node from the gripper_name
-    YAML::Node single_gripper = all_grippers[gripper_name];
-    // initialize a Gripper struct to save the info about this gripper
-    Gripper gripper;
-    // load all info from the single_gripper node into the Griper struct, substituting the default
-    //  values if not given the value
-    gripper.horn_radius = single_gripper["horn_radius"].as<float>(0.014);
-    gripper.arm_length = single_gripper["arm_length"].as<float>(0.024);
-    gripper.left_finger = single_gripper["left_finger"].as<std::string>("left_finger");
-    gripper.right_finger = single_gripper["right_finger"].as<std::string>("right_finger");
-    gripper_map.insert({gripper_name, gripper});
-  }
-
-  // create joint_order node from 'joint_order'
-  YAML::Node joint_order = motor_configs["joint_order"];
-  // create sleep_positions node from 'sleep_positions'
-  YAML::Node sleep_positions = motor_configs["sleep_positions"];
-  // create JointGroup struct for all_joints - contains all joints in robot
-  JointGroup all_joints;
-  all_joints.joint_num = (uint8_t) joint_order.size();
-  all_joints.mode = mode::POSITION;
-  all_joints.profile_type = profile::VELOCITY;
-  all_joints.profile_velocity = DEFAULT_PROF_VEL;
-  all_joints.profile_acceleration = DEFAULT_PROF_ACC;
-  for (size_t i{0}; i < joint_order.size(); i++) {
-    // iterate through each joint in joint_order list
-    // save each joint ID and name
-    std::string joint_name = joint_order[i].as<std::string>();
-    all_joints.joint_names.push_back(joint_name);
-    all_joints.joint_ids.push_back(motor_map[joint_name].motor_id);
-    // add this joint's index to the js_index_map
-    js_index_map.insert({joint_name, i});
-    // add any shadows
-    shadow_map.insert({joint_name, {joint_name}});
-    // add any sisters
-    sister_map.insert({joint_name, {joint_name}});
-    // add the sleep position of this joint, defaults to 0 if not specified
-    sleep_map.insert({joint_name, sleep_positions[i].as<float>(0)});
-    // if this joint is a gripper, add it to the gripper_name
-    if (gripper_map.count(joint_name) > 0) {
-      gripper_map[joint_name].js_index = i;
-      gripper_order.push_back(joint_name);
-    }
-  }
-
-  // append the left and right finger to the gripper_map
-  for (auto const & name : gripper_order) {
-    js_index_map.insert({gripper_map[name].left_finger, js_index_map.size()});
-    js_index_map.insert({gripper_map[name].right_finger, js_index_map.size()});
-  }
-
-  // all the all_joints JointGroup to the group_map
-  group_map.insert({"all", all_joints});
-  // create a pointer from the group_map's all group reference
-  all_ptr = &group_map.at("all");
-
-  // create all_shadows node from 'shadows'
-  YAML::Node all_shadows = motor_configs["shadows"];
-  for (
-    YAML::const_iterator master_itr = all_shadows.begin();
-    master_itr != all_shadows.end();
-    master_itr++)
-  {
-    // iterate through each shadow servo's master in all_shadows node
-    std::string master_name = master_itr->first.as<std::string>();
-    YAML::Node master = all_shadows[master_name];
-    YAML::Node shadow_list = master["shadow_list"];
-    for (size_t i{0}; i < shadow_list.size(); i++) {
-      shadow_map[master_name].push_back(shadow_list[i].as<std::string>());
-    }
-  }
-
-  // create all_sisters node from 'sisters'
-  YAML::Node all_sisters = motor_configs["sisters"];
-  for (
-    YAML::const_iterator sister_itr = all_sisters.begin();
-    sister_itr != all_sisters.end();
-    sister_itr++)
-  {
-    // iterate through each sister servo in all_sisters node
-    // save each 2-in-1 servo to the sister_map
-    std::string sister_one = sister_itr->first.as<std::string>();
-    std::string sister_two = sister_itr->second.as<std::string>();
-    sister_map[sister_one].push_back(sister_two);
-    sister_map[sister_two].push_back(sister_one);
-  }
-
-  // create all_groups node from 'groups'
-  YAML::Node all_groups = motor_configs["groups"];
-  for (
-    YAML::const_iterator group_itr = all_groups.begin();
-    group_itr != all_groups.end();
-    group_itr++)
-  {
-    // iterate through each sister servo in all_sisters node
-    // get the name of the group
-    std::string name = group_itr->first.as<std::string>();
-    // get the list of joints in the group from the all_group map
-    YAML::Node joint_list = all_groups[name];
-    // create a JointGroup for this group
-    JointGroup group;
-    // the number of joints in this group is the size of the list of joints
-    group.joint_num = (uint8_t) joint_list.size();
-    for (size_t i{0}; i < joint_list.size(); i++) {
-      // add each joint's name and id to the JointGroup
-      std::string joint_name = joint_list[i].as<std::string>();
-      group.joint_names.push_back(joint_name);
-      group.joint_ids.push_back(motor_map[joint_name].motor_id);
-    }
-    // add the JointGroup and its name to the group_map
-    group_map.insert({name, group});
-  }
-
-  XSLOG_INFO(
-    "Loaded motor configs from '%s'.",
-    filepath_motor_configs.c_str());
-  return true;
+    return found_all_motors;
 }
 
-bool InterbotixDriverXS::init_port()
-{
-  // try to connect to the specified port at the default baudrate
-  if (!dxl_wb.init(port.c_str(), DEFAULT_BAUDRATE)) {
-    // if the connection fails, shut down
-    XSLOG_FATAL(
-      "Failed to open port at '%s'. Shutting down...",
-      port.c_str());
-    return false;
-  }
-  return true;
+bool InterbotixDriverXS::load_motor_configs() {
+    // result is true by default, if can't write config, set this to false
+    bool wrote_all_configs = true;
+    for (const auto& motor_info : motor_info_vec) {
+        if (!dxl_wb.itemWrite(motor_info.motor_id, motor_info.reg.c_str(), motor_info.value)) {
+            XSLOG_FATAL("Failed to write value[%d] on items[%s] to [ID : %2.d]", motor_info.value,
+                        motor_info.reg.c_str(), motor_info.motor_id);
+            wrote_all_configs = false;
+        }
+    }
+    return wrote_all_configs;
 }
 
-bool InterbotixDriverXS::ping_motors()
-{
-  // result is true by default, if can't find motor, set this to false
-  bool found_all_motors = true;
-  const char * log;
-  for (size_t cntr_ping_motors = 0; cntr_ping_motors < 3; cntr_ping_motors++) {
-    XSLOG_INFO(
-      "Pinging all motors specified in the motor_config file. (Attempt %ld/3)",
-      cntr_ping_motors + 1);
-    // iterate through each servo in the motor_map
-    for (const auto &[motor_name, motor_state] : motor_map) {
-      // try to ping the servo
-      if (!dxl_wb.ping(motor_state.motor_id, &log)) {
-        // if any ping is unsuccessful, shut down
-        XSLOG_ERROR(
-          "\tCan't find DYNAMIXEL ID: %2.d, Joint Name: '%s':\n\t\t  '%s'",
-          motor_state.motor_id, motor_name.c_str(), log);
-        found_all_motors = false;
-      } else {
-        XSLOG_INFO(
-          "\tFound DYNAMIXEL ID: %2.d, Model: '%s', Joint Name: '%s'.",
-          motor_state.motor_id, dxl_wb.getModelName(motor_state.motor_id), motor_name.c_str());
-      }
-      // untorque each pinged servo, need to write data to the EEPROM
-      dxl_wb.torque(motor_state.motor_id, false);
+bool InterbotixDriverXS::init_controlItems() {
+    uint8_t motor_id = motor_map.begin()->second.motor_id;
+
+    const ControlItem* goal_position = dxl_wb.getItemInfo(motor_id, "Goal_Position");
+    if (!goal_position) {
+        XSLOG_ERROR("Could not get 'Goal_Position' Item Info");
+        return false;
     }
-    if (found_all_motors) {
-      return found_all_motors;
+
+    const ControlItem* goal_velocity = dxl_wb.getItemInfo(motor_id, "Goal_Velocity");
+    if (!goal_velocity) {
+        goal_velocity = dxl_wb.getItemInfo(motor_id, "Moving_Speed");
     }
-  }
-  return found_all_motors;
+    if (!goal_velocity) {
+        XSLOG_ERROR("Could not get 'Goal_Velocity' or 'Moving_Speed' Item Info");
+        return false;
+    }
+
+    const ControlItem* goal_current = NULL;
+    for (const auto& [_, motor_info] : motor_map) {
+        goal_current = dxl_wb.getItemInfo(motor_info.motor_id, "Goal_Current");
+        if (goal_current) {
+            break;
+        }
+    }
+
+    if (!goal_current) {
+        XSLOG_WARN("Could not get 'Goal_Current' Item Info. This message can be "
+                   "ignored if none of the robot's motors support current control.");
+    }
+
+    const ControlItem* goal_pwm = dxl_wb.getItemInfo(motor_id, "Goal_PWM");
+    if (!goal_pwm) {
+        XSLOG_ERROR("Could not get 'Goal_PWM' Item Info");
+        return false;
+    }
+
+    const ControlItem* present_position = dxl_wb.getItemInfo(motor_id, "Present_Position");
+    if (!present_position) {
+        XSLOG_ERROR("Could not get 'Present_Position' Item Info");
+        return false;
+    }
+
+    const ControlItem* present_velocity = dxl_wb.getItemInfo(motor_id, "Present_Velocity");
+    if (!present_velocity) {
+        present_velocity = dxl_wb.getItemInfo(motor_id, "Present_Speed");
+    }
+    if (!present_velocity) {
+        XSLOG_ERROR("Could not get 'Present_Velocity' or 'Present_Speed' Item Info");
+        return false;
+    }
+
+    const ControlItem* present_current = dxl_wb.getItemInfo(motor_id, "Present_Current");
+    if (!present_current) {
+        present_current = dxl_wb.getItemInfo(motor_id, "Present_Load");
+    }
+    if (!present_current) {
+        XSLOG_FATAL("Could not get 'Present_Current' or 'Present_Load' Item Info");
+        return false;
+    }
+
+    control_items["Goal_Position"] = goal_position;
+    control_items["Goal_Velocity"] = goal_velocity;
+    control_items["Goal_Current"] = goal_current;
+    control_items["Goal_PWM"] = goal_pwm;
+    control_items["Present_Position"] = present_position;
+    control_items["Present_Velocity"] = present_velocity;
+    control_items["Present_Current"] = present_current;
+    return true;
 }
 
-bool InterbotixDriverXS::load_motor_configs()
-{
-  // result is true by default, if can't write config, set this to false
-  bool wrote_all_configs = true;
-  for (auto const & motor_info : motor_info_vec) {
-    if (!dxl_wb.itemWrite(motor_info.motor_id, motor_info.reg.c_str(), motor_info.value)) {
-      XSLOG_FATAL(
-        "Failed to write value[%d] on items[%s] to [ID : %2.d]",
-        motor_info.value, motor_info.reg.c_str(), motor_info.motor_id);
-      wrote_all_configs = false;
+bool InterbotixDriverXS::init_workbench_handlers() {
+    if (!dxl_wb.addSyncWriteHandler(control_items["Goal_Position"]->address,
+                                    control_items["Goal_Position"]->data_length)) {
+        XSLOG_FATAL("Failed to add SyncWriteHandler for Goal_Position.");
+        return false;
     }
-  }
-  return wrote_all_configs;
-}
 
-bool InterbotixDriverXS::init_controlItems()
-{
-  uint8_t motor_id = motor_map.begin()->second.motor_id;
-
-  const ControlItem * goal_position = dxl_wb.getItemInfo(motor_id, "Goal_Position");
-  if (!goal_position) {
-    XSLOG_ERROR("Could not get 'Goal_Position' Item Info");
-    return false;
-  }
-
-  const ControlItem * goal_velocity = dxl_wb.getItemInfo(motor_id, "Goal_Velocity");
-  if (!goal_velocity) {
-    goal_velocity = dxl_wb.getItemInfo(motor_id, "Moving_Speed");
-  }
-  if (!goal_velocity) {
-    XSLOG_ERROR("Could not get 'Goal_Velocity' or 'Moving_Speed' Item Info");
-    return false;
-  }
-
-  const ControlItem * goal_current = NULL;
-  for (auto const & [_, motor_info] : motor_map) {
-    goal_current = dxl_wb.getItemInfo(motor_info.motor_id, "Goal_Current");
-    if (goal_current) {
-      break;
+    if (!dxl_wb.addSyncWriteHandler(control_items["Goal_Velocity"]->address,
+                                    control_items["Goal_Velocity"]->data_length)) {
+        XSLOG_FATAL("Failed to add SyncWriteHandler for Goal_Velocity.");
+        return false;
     }
-  }
 
-  if (!goal_current) {
-    XSLOG_WARN(
-      "Could not get 'Goal_Current' Item Info. This message can be "
-      "ignored if none of the robot's motors support current control.");
-  }
-
-  const ControlItem * goal_pwm = dxl_wb.getItemInfo(motor_id, "Goal_PWM");
-  if (!goal_pwm) {
-    XSLOG_ERROR("Could not get 'Goal_PWM' Item Info");
-    return false;
-  }
-
-  const ControlItem * present_position = dxl_wb.getItemInfo(motor_id, "Present_Position");
-  if (!present_position) {
-    XSLOG_ERROR("Could not get 'Present_Position' Item Info");
-    return false;
-  }
-
-  const ControlItem * present_velocity = dxl_wb.getItemInfo(motor_id, "Present_Velocity");
-  if (!present_velocity) {
-    present_velocity = dxl_wb.getItemInfo(motor_id, "Present_Speed");
-  }
-  if (!present_velocity) {
-    XSLOG_ERROR("Could not get 'Present_Velocity' or 'Present_Speed' Item Info");
-    return false;
-  }
-
-  const ControlItem * present_current = dxl_wb.getItemInfo(motor_id, "Present_Current");
-  if (!present_current) {
-    present_current = dxl_wb.getItemInfo(motor_id, "Present_Load");
-  }
-  if (!present_current) {
-    XSLOG_FATAL("Could not get 'Present_Current' or 'Present_Load' Item Info");
-    return false;
-  }
-
-  control_items["Goal_Position"] = goal_position;
-  control_items["Goal_Velocity"] = goal_velocity;
-  control_items["Goal_Current"] = goal_current;
-  control_items["Goal_PWM"] = goal_pwm;
-  control_items["Present_Position"] = present_position;
-  control_items["Present_Velocity"] = present_velocity;
-  control_items["Present_Current"] = present_current;
-  return true;
-}
-
-bool InterbotixDriverXS::init_workbench_handlers()
-{
-  if (
-    !dxl_wb.addSyncWriteHandler(
-      control_items["Goal_Position"]->address, control_items["Goal_Position"]->data_length))
-  {
-    XSLOG_FATAL("Failed to add SyncWriteHandler for Goal_Position.");
-    return false;
-  }
-
-  if (
-    !dxl_wb.addSyncWriteHandler(
-      control_items["Goal_Velocity"]->address, control_items["Goal_Velocity"]->data_length))
-  {
-    XSLOG_FATAL("Failed to add SyncWriteHandler for Goal_Velocity.");
-    return false;
-  }
-
-  // only add a SyncWriteHandler for 'Goal_Current' if the register actually exists!
-  if (control_items["Goal_Current"]) {
-    if (
-      !dxl_wb.addSyncWriteHandler(
-        control_items["Goal_Current"]->address, control_items["Goal_Current"]->data_length))
-    {
-      XSLOG_FATAL("Failed to add SyncWriteHandler for Goal_Current.");
-      return false;
+    // only add a SyncWriteHandler for 'Goal_Current' if the register actually
+    // exists!
+    if (control_items["Goal_Current"]) {
+        if (!dxl_wb.addSyncWriteHandler(control_items["Goal_Current"]->address,
+                                        control_items["Goal_Current"]->data_length)) {
+            XSLOG_FATAL("Failed to add SyncWriteHandler for Goal_Current.");
+            return false;
+        }
     }
-  } else {
-    XSLOG_WARN("SyncWriteHandler for Goal_Current not added as it's not supported.");
-  }
+    else {
+        XSLOG_WARN("SyncWriteHandler for Goal_Current not added as it's not "
+                   "supported.");
+    }
 
-  if (
-    !dxl_wb.addSyncWriteHandler(
-      control_items["Goal_PWM"]->address, control_items["Goal_PWM"]->data_length))
-  {
-    XSLOG_FATAL("Failed to add SyncWriteHandler for Goal_PWM.");
-    return false;
-  }
+    if (!dxl_wb.addSyncWriteHandler(control_items["Goal_PWM"]->address,
+                                    control_items["Goal_PWM"]->data_length)) {
+        XSLOG_FATAL("Failed to add SyncWriteHandler for Goal_PWM.");
+        return false;
+    }
 
-  if (dxl_wb.getProtocolVersion() == 2.0f) {
-    uint16_t start_address = std::min(
-      control_items["Present_Position"]->address,
-      control_items["Present_Current"]->address);
-    /*
-      As some models have an empty space between Present_Velocity and Present Current, read_length
-      is modified as below.
-    */
-    // uint16_t read_length = control_items["Present_Position"]->data_length \
+    if (dxl_wb.getProtocolVersion() == 2.0f) {
+        uint16_t start_address = std::min(control_items["Present_Position"]->address,
+                                          control_items["Present_Current"]->address);
+        /*
+          As some models have an empty space between Present_Velocity and
+          Present Current, read_length is modified as below.
+        */
+        // uint16_t read_length = control_items["Present_Position"]->data_length \
     //   + control_items["Present_Velocity"]->data_length \
     //   + control_items["Present_Current"]->data_length;
-    uint16_t read_length = control_items["Present_Position"]->data_length + \
-      control_items["Present_Velocity"]->data_length + \
-      control_items["Present_Current"]->data_length + \
-      2;
-    if (!dxl_wb.addSyncReadHandler(start_address, read_length)) {
-      XSLOG_FATAL("Failed to add SyncReadHandler.");
-      return false;
-    }
-  }
-  return true;
-}
-
-void InterbotixDriverXS::init_operating_modes()
-{
-  YAML::Node all_shadows = motor_configs["shadows"];
-  for (
-    YAML::const_iterator master_itr = all_shadows.begin();
-    master_itr != all_shadows.end();
-    master_itr++)
-  {
-    std::string master_name = master_itr->first.as<std::string>();
-    YAML::Node master = all_shadows[master_name];
-    if (master["calibrate"].as<bool>(false)) {
-      int32_t master_position;
-      dxl_wb.itemRead(motor_map[master_name].motor_id, "Present_Position", &master_position);
-      for (auto const & shadow_name : shadow_map[master_name]) {
-        if (shadow_name == master_name) {
-          continue;
+        uint16_t read_length = control_items["Present_Position"]->data_length +
+                               control_items["Present_Velocity"]->data_length +
+                               control_items["Present_Current"]->data_length + 2;
+        if (!dxl_wb.addSyncReadHandler(start_address, read_length)) {
+            XSLOG_FATAL("Failed to add SyncReadHandler.");
+            return false;
         }
-        dxl_wb.itemWrite(motor_map[shadow_name].motor_id, "Homing_Offset", 0);
-        int32_t shadow_position, shadow_drive_mode;
-        dxl_wb.itemRead(motor_map[shadow_name].motor_id, "Present_Position", &shadow_position);
-        dxl_wb.itemRead(motor_map[shadow_name].motor_id, "Drive_Mode", &shadow_drive_mode);
-        // The 0th (0x01) bit of the Drive_Mode register sets Normal/Reverse Mode
-        // [0/false]: Normal Mode: CCW(Positive), CW(Negative)
-        // [1/true]: Reverse Mode: CCW(Negative), CW(Positive)
-        // This mode dictates how to calculate the homing offset of the shadow motor
-        std::bitset<8> shadow_drive_mode_bitset = shadow_drive_mode;
-        int32_t homing_offset;
-        if (shadow_drive_mode_bitset.test(0)) {
-          homing_offset = master_position - shadow_position;
-        } else {
-          homing_offset = shadow_position - master_position;
+    }
+    return true;
+}
+
+void InterbotixDriverXS::init_operating_modes() {
+    YAML::Node all_shadows = motor_configs["shadows"];
+    for (YAML::const_iterator master_itr = all_shadows.begin(); master_itr != all_shadows.end();
+         master_itr++) {
+        std::string master_name = master_itr->first.as<std::string>();
+        YAML::Node master = all_shadows[master_name];
+        if (master["calibrate"].as<bool>(false)) {
+            int32_t master_position;
+            dxl_wb.itemRead(motor_map[master_name].motor_id, "Present_Position", &master_position);
+            for (const auto& shadow_name : shadow_map[master_name]) {
+                if (shadow_name == master_name) {
+                    continue;
+                }
+                dxl_wb.itemWrite(motor_map[shadow_name].motor_id, "Homing_Offset", 0);
+                int32_t shadow_position, shadow_drive_mode;
+                dxl_wb.itemRead(motor_map[shadow_name].motor_id, "Present_Position",
+                                &shadow_position);
+                dxl_wb.itemRead(motor_map[shadow_name].motor_id, "Drive_Mode", &shadow_drive_mode);
+                // The 0th (0x01) bit of the Drive_Mode register sets
+                // Normal/Reverse Mode [0/false]: Normal Mode: CCW(Positive),
+                // CW(Negative) [1/true]: Reverse Mode: CCW(Negative),
+                // CW(Positive) This mode dictates how to calculate the homing
+                // offset of the shadow motor
+                std::bitset<8> shadow_drive_mode_bitset = shadow_drive_mode;
+                int32_t homing_offset;
+                if (shadow_drive_mode_bitset.test(0)) {
+                    homing_offset = master_position - shadow_position;
+                }
+                else {
+                    homing_offset = shadow_position - master_position;
+                }
+                dxl_wb.itemWrite(motor_map[shadow_name].motor_id, "Homing_Offset", homing_offset);
+            }
         }
-        dxl_wb.itemWrite(motor_map[shadow_name].motor_id, "Homing_Offset", homing_offset);
-      }
-    }
-  }
-
-  YAML::Node all_groups = mode_configs["groups"];
-  for (
-    YAML::const_iterator group_itr = all_groups.begin();
-    group_itr != all_groups.end();
-    group_itr++)
-  {
-    std::string name = group_itr->first.as<std::string>();
-    YAML::Node single_group = all_groups[name];
-    const std::string operating_mode =
-      single_group["operating_mode"].as<std::string>(DEFAULT_OP_MODE);
-    const std::string profile_type =
-      single_group["profile_type"].as<std::string>(DEFAULT_PROF_TYPE);
-    int32_t profile_velocity = single_group["profile_velocity"].as<int32_t>(DEFAULT_PROF_VEL);
-    int32_t profile_acceleration =
-      single_group["profile_acceleration"].as<int32_t>(DEFAULT_PROF_ACC);
-    set_operating_modes(
-      cmd_type::GROUP,
-      name,
-      operating_mode,
-      profile_type,
-      profile_velocity,
-      profile_acceleration);
-    if (!single_group["torque_enable"].as<bool>(TORQUE_ENABLE)) {
-      torque_enable(cmd_type::GROUP, name, false);
-    }
-  }
-
-  YAML::Node all_singles = mode_configs["singles"];
-  for (
-    YAML::const_iterator single_itr = all_singles.begin();
-    single_itr != all_singles.end();
-    single_itr++)
-  {
-    std::string single_name = single_itr->first.as<std::string>();
-    YAML::Node single_joint = all_singles[single_name];
-    const std::string operating_mode =
-      single_joint["operating_mode"].as<std::string>(DEFAULT_OP_MODE);
-    const std::string profile_type =
-      single_joint["profile_type"].as<std::string>(DEFAULT_PROF_TYPE);
-    int32_t profile_velocity = single_joint["profile_velocity"].as<int32_t>(DEFAULT_PROF_VEL);
-    int32_t profile_acceleration =
-      single_joint["profile_acceleration"].as<int32_t>(DEFAULT_PROF_ACC);
-    set_operating_modes(
-      cmd_type::SINGLE,
-      single_name,
-      operating_mode,
-      profile_type,
-      profile_velocity,
-      profile_acceleration);
-    if (!single_joint["torque_enable"].as<bool>(TORQUE_ENABLE)) {
-      torque_enable(cmd_type::SINGLE, single_name, false);
-    }
-  }
-}
-
-void InterbotixDriverXS::read_joint_states()
-{
-  std::lock_guard<std::mutex> guard(_mutex_js);
-  robot_positions.clear();
-  robot_velocities.clear();
-  robot_efforts.clear();
-  const char * log;
-
-  std::vector<int32_t> get_current(all_ptr->joint_num, 0);
-  std::vector<int32_t> get_velocity(all_ptr->joint_num, 0);
-  std::vector<int32_t> get_position(all_ptr->joint_num, 0);
-
-  if (dxl_wb.getProtocolVersion() == 2.0f) {
-    // Checks if data can be sent properly
-    if (!dxl_wb.syncRead(
-        SYNC_READ_HANDLER_FOR_PRESENT_POSITION_VELOCITY_CURRENT,
-        all_ptr->joint_ids.data(),
-        all_ptr->joint_num,
-        &log))
-    {
-      XSLOG_ERROR("%s", log);
     }
 
-    // Gets present current of all servos
-    if (!dxl_wb.getSyncReadData(
-        SYNC_READ_HANDLER_FOR_PRESENT_POSITION_VELOCITY_CURRENT,
-        all_ptr->joint_ids.data(),
-        all_ptr->joint_num,
-        control_items["Present_Current"]->address,
-        control_items["Present_Current"]->data_length,
-        get_current.data(),
-        &log))
-    {
-      XSLOG_ERROR("%s", log);
+    YAML::Node all_groups = mode_configs["groups"];
+    for (YAML::const_iterator group_itr = all_groups.begin(); group_itr != all_groups.end();
+         group_itr++) {
+        std::string name = group_itr->first.as<std::string>();
+        YAML::Node single_group = all_groups[name];
+        const std::string operating_mode =
+            single_group["operating_mode"].as<std::string>(DEFAULT_OP_MODE);
+        const std::string profile_type =
+            single_group["profile_type"].as<std::string>(DEFAULT_PROF_TYPE);
+        int32_t profile_velocity = single_group["profile_velocity"].as<int32_t>(DEFAULT_PROF_VEL);
+        int32_t profile_acceleration =
+            single_group["profile_acceleration"].as<int32_t>(DEFAULT_PROF_ACC);
+        set_operating_modes(cmd_type::GROUP, name, operating_mode, profile_type, profile_velocity,
+                            profile_acceleration);
+        if (!single_group["torque_enable"].as<bool>(TORQUE_ENABLE)) {
+            torque_enable(cmd_type::GROUP, name, false);
+        }
     }
 
-    // Gets present velocity of all servos
-    if (!dxl_wb.getSyncReadData(
-        SYNC_READ_HANDLER_FOR_PRESENT_POSITION_VELOCITY_CURRENT,
-        all_ptr->joint_ids.data(),
-        all_ptr->joint_num,
-        control_items["Present_Velocity"]->address,
-        control_items["Present_Velocity"]->data_length,
-        get_velocity.data(),
-        &log))
-    {
-      XSLOG_ERROR("%s", log);
+    YAML::Node all_singles = mode_configs["singles"];
+    for (YAML::const_iterator single_itr = all_singles.begin(); single_itr != all_singles.end();
+         single_itr++) {
+        std::string single_name = single_itr->first.as<std::string>();
+        YAML::Node single_joint = all_singles[single_name];
+        const std::string operating_mode =
+            single_joint["operating_mode"].as<std::string>(DEFAULT_OP_MODE);
+        const std::string profile_type =
+            single_joint["profile_type"].as<std::string>(DEFAULT_PROF_TYPE);
+        int32_t profile_velocity = single_joint["profile_velocity"].as<int32_t>(DEFAULT_PROF_VEL);
+        int32_t profile_acceleration =
+            single_joint["profile_acceleration"].as<int32_t>(DEFAULT_PROF_ACC);
+        set_operating_modes(cmd_type::SINGLE, single_name, operating_mode, profile_type,
+                            profile_velocity, profile_acceleration);
+        if (!single_joint["torque_enable"].as<bool>(TORQUE_ENABLE)) {
+            torque_enable(cmd_type::SINGLE, single_name, false);
+        }
     }
+}
 
-    // Gets present position of all servos
-    if (!dxl_wb.getSyncReadData(
-        SYNC_READ_HANDLER_FOR_PRESENT_POSITION_VELOCITY_CURRENT,
-        all_ptr->joint_ids.data(),
-        all_ptr->joint_num,
-        control_items["Present_Position"]->address,
-        control_items["Present_Position"]->data_length,
-        get_position.data(),
-        &log))
-    {
-      XSLOG_ERROR("%s", log);
+void InterbotixDriverXS::read_joint_states() {
+    std::lock_guard<std::mutex> guard(_mutex_js);
+    robot_positions.clear();
+    robot_velocities.clear();
+    robot_efforts.clear();
+    const char* log;
+
+    std::vector<int32_t> get_current(all_ptr->joint_num, 0);
+    std::vector<int32_t> get_velocity(all_ptr->joint_num, 0);
+    std::vector<int32_t> get_position(all_ptr->joint_num, 0);
+
+    if (dxl_wb.getProtocolVersion() == 2.0f) {
+        // Checks if data can be sent properly
+        if (!dxl_wb.syncRead(SYNC_READ_HANDLER_FOR_PRESENT_POSITION_VELOCITY_CURRENT,
+                             all_ptr->joint_ids.data(), all_ptr->joint_num, &log)) {
+            XSLOG_ERROR("%s", log);
+        }
+
+        // Gets present current of all servos
+        if (!dxl_wb.getSyncReadData(
+                SYNC_READ_HANDLER_FOR_PRESENT_POSITION_VELOCITY_CURRENT, all_ptr->joint_ids.data(),
+                all_ptr->joint_num, control_items["Present_Current"]->address,
+                control_items["Present_Current"]->data_length, get_current.data(), &log)) {
+            XSLOG_ERROR("%s", log);
+        }
+
+        // Gets present velocity of all servos
+        if (!dxl_wb.getSyncReadData(
+                SYNC_READ_HANDLER_FOR_PRESENT_POSITION_VELOCITY_CURRENT, all_ptr->joint_ids.data(),
+                all_ptr->joint_num, control_items["Present_Velocity"]->address,
+                control_items["Present_Velocity"]->data_length, get_velocity.data(), &log)) {
+            XSLOG_ERROR("%s", log);
+        }
+
+        // Gets present position of all servos
+        if (!dxl_wb.getSyncReadData(
+                SYNC_READ_HANDLER_FOR_PRESENT_POSITION_VELOCITY_CURRENT, all_ptr->joint_ids.data(),
+                all_ptr->joint_num, control_items["Present_Position"]->address,
+                control_items["Present_Position"]->data_length, get_position.data(), &log)) {
+            XSLOG_ERROR("%s", log);
+        }
+
+        uint8_t index = 0;
+        for (const auto& id : all_ptr->joint_ids) {
+            float position = 0;
+            float velocity = 0;
+            float effort = 0;
+
+            if (strcmp(dxl_wb.getModelName(id), "XL-320") == 0) {
+                effort = dxl_wb.convertValue2Load(get_current.at(index));
+            }
+            else {
+                effort = dxl_wb.convertValue2Current(get_current.at(index));
+            }
+            velocity = dxl_wb.convertValue2Velocity(id, get_velocity.at(index));
+            position = dxl_wb.convertValue2Radian(id, get_position.at(index));
+            robot_efforts.push_back(effort);
+            robot_velocities.push_back(velocity);
+            robot_positions.push_back(position);
+            index++;
+        }
     }
+    else if (dxl_wb.getProtocolVersion() == 1.0f) {
+        uint16_t length_of_data = control_items["Present_Position"]->data_length +
+                                  control_items["Present_Velocity"]->data_length +
+                                  control_items["Present_Current"]->data_length;
+        std::vector<uint32_t> get_all_data(length_of_data, 0);
 
-    uint8_t index = 0;
-    for (auto const & id : all_ptr->joint_ids) {
-      float position = 0;
-      float velocity = 0;
-      float effort = 0;
+        for (const auto& id : all_ptr->joint_ids) {
+            if (!dxl_wb.readRegister(id, control_items["Present_Position"]->address, length_of_data,
+                                     get_all_data.data(), &log)) {
+                XSLOG_ERROR("%s", log);
+            }
 
-      if (strcmp(dxl_wb.getModelName(id), "XL-320") == 0) {
-        effort = dxl_wb.convertValue2Load(get_current.at(index));
-      } else {
-        effort = dxl_wb.convertValue2Current(get_current.at(index));
-      }
-      velocity = dxl_wb.convertValue2Velocity(id, get_velocity.at(index));
-      position = dxl_wb.convertValue2Radian(id, get_position.at(index));
-      robot_efforts.push_back(effort);
-      robot_velocities.push_back(velocity);
-      robot_positions.push_back(position);
-      index++;
+            int16_t effort_raw = DXL_MAKEWORD(get_all_data.at(4), get_all_data.at(5));
+            int32_t velocity_raw = DXL_MAKEWORD(get_all_data.at(2), get_all_data.at(3));
+            int32_t position_raw = DXL_MAKEWORD(get_all_data.at(0), get_all_data.at(1));
+
+            // Convert raw register values to the metric system
+            float effort = dxl_wb.convertValue2Load(effort_raw);
+            float velocity = dxl_wb.convertValue2Velocity(id, velocity_raw);
+            float position = dxl_wb.convertValue2Radian(id, position_raw);
+
+            robot_efforts.push_back(effort);
+            robot_velocities.push_back(velocity);
+            robot_positions.push_back(position);
+        }
     }
-  } else if (dxl_wb.getProtocolVersion() == 1.0f) {
-    uint16_t length_of_data = control_items["Present_Position"]->data_length +
-      control_items["Present_Velocity"]->data_length +
-      control_items["Present_Current"]->data_length;
-    std::vector<uint32_t> get_all_data(length_of_data, 0);
+}
 
-    for (auto const & id : all_ptr->joint_ids) {
-      if (!dxl_wb.readRegister(
-          id,
-          control_items["Present_Position"]->address,
-          length_of_data,
-          get_all_data.data(),
-          &log))
-      {
-        XSLOG_ERROR("%s", log);
-      }
+std::vector<std::string> InterbotixDriverXS::get_all_joint_names() {
+    return all_ptr->joint_names;
+}
 
-      int16_t effort_raw = DXL_MAKEWORD(get_all_data.at(4), get_all_data.at(5));
-      int32_t velocity_raw = DXL_MAKEWORD(get_all_data.at(2), get_all_data.at(3));
-      int32_t position_raw = DXL_MAKEWORD(get_all_data.at(0), get_all_data.at(1));
+float InterbotixDriverXS::get_joint_sleep_position(const std::string& name) {
+    return sleep_map[name];
+}
 
-      // Convert raw register values to the metric system
-      float effort = dxl_wb.convertValue2Load(effort_raw);
-      float velocity = dxl_wb.convertValue2Velocity(id, velocity_raw);
-      float position = dxl_wb.convertValue2Radian(id, position_raw);
+std::unordered_map<std::string, JointGroup>* InterbotixDriverXS::get_group_map() {
+    return &group_map;
+}
 
-      robot_efforts.push_back(effort);
-      robot_velocities.push_back(velocity);
-      robot_positions.push_back(position);
+std::unordered_map<std::string, MotorState>* InterbotixDriverXS::get_motor_map() {
+    return &motor_map;
+}
+
+JointGroup* InterbotixDriverXS::get_group_info(const std::string& name) {
+    return &group_map.at(name);
+}
+
+MotorState* InterbotixDriverXS::get_motor_info(const std::string& name) {
+    return &motor_map.at(name);
+}
+
+Gripper* InterbotixDriverXS::get_gripper_info(const std::string& name) {
+    return &gripper_map.at(name);
+}
+
+std::vector<std::string> InterbotixDriverXS::get_gripper_order() {
+    return gripper_order;
+}
+
+size_t InterbotixDriverXS::get_js_index(const std::string& name) {
+    return js_index_map.at(name);
+}
+
+bool InterbotixDriverXS::is_motor_gripper(const std::string& name) {
+    return gripper_map.count(name) > 0;
+}
+
+bool InterbotixDriverXS::go_to_sleep_configuration(const std::string& name, const bool blocking) {
+    XSLOG_DEBUG("Sending robot to sleep configuration.");
+    std::vector<float> sleep_positions;
+    for (const auto& joint_name : get_group_info(name)->joint_names) {
+        sleep_positions.push_back(get_joint_sleep_position(joint_name));
     }
-  }
+    return write_position_commands(name, sleep_positions, blocking);
 }
 
-std::vector<std::string> InterbotixDriverXS::get_all_joint_names()
-{
-  return all_ptr->joint_names;
-}
-
-float InterbotixDriverXS::get_joint_sleep_position(const std::string & name)
-{
-  return sleep_map[name];
-}
-
-std::unordered_map<std::string, JointGroup> * InterbotixDriverXS::get_group_map()
-{
-  return &group_map;
-}
-
-std::unordered_map<std::string, MotorState> * InterbotixDriverXS::get_motor_map()
-{
-  return &motor_map;
-}
-
-JointGroup * InterbotixDriverXS::get_group_info(const std::string & name)
-{
-  return &group_map.at(name);
-}
-
-MotorState * InterbotixDriverXS::get_motor_info(const std::string & name)
-{
-  return &motor_map.at(name);
-}
-
-Gripper * InterbotixDriverXS::get_gripper_info(const std::string & name)
-{
-  return &gripper_map.at(name);
-}
-
-std::vector<std::string> InterbotixDriverXS::get_gripper_order()
-{
-  return gripper_order;
-}
-
-size_t InterbotixDriverXS::get_js_index(const std::string & name)
-{
-  return js_index_map.at(name);
-}
-
-bool InterbotixDriverXS::is_motor_gripper(const std::string & name)
-{
-  return gripper_map.count(name) > 0;
-}
-
-bool InterbotixDriverXS::go_to_sleep_configuration(
-  const std::string & name,
-  const bool blocking)
-{
-  XSLOG_DEBUG("Sending robot to sleep configuration.");
-  std::vector<float> sleep_positions;
-  for (auto const & joint_name : get_group_info(name)->joint_names) {
-    sleep_positions.push_back(get_joint_sleep_position(joint_name));
-  }
-  return write_position_commands(name, sleep_positions, blocking);
-}
-
-bool InterbotixDriverXS::go_to_home_configuration(
-  const std::string & name,
-  const bool blocking)
-{
-  XSLOG_DEBUG("Sending robot to home configuration.");
-  std::vector<float> home_positions(get_group_info(name)->joint_num, 0.0);
-  return write_position_commands(name, home_positions, blocking);
+bool InterbotixDriverXS::go_to_home_configuration(const std::string& name, const bool blocking) {
+    XSLOG_DEBUG("Sending robot to home configuration.");
+    std::vector<float> home_positions(get_group_info(name)->joint_num, 0.0);
+    return write_position_commands(name, home_positions, blocking);
 }
 
 }  // namespace interbotix_xs

--- a/src/xs_logging.cpp
+++ b/src/xs_logging.cpp
@@ -31,14 +31,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <memory>
 #include <cstdarg>
 #include <cstdio>
+#include <iostream>
+#include <memory>
 #include <sstream>
 #include <string>
 #include <vector>
-#include <iostream>
-
 
 namespace interbotix_xs
 {
@@ -52,90 +51,90 @@ namespace logging
 #define YLW "\x1B[33m"
 #define RED "\x1B[31m"
 
-void log(logging::Level level, const char * fmt, ...)
-{
-  std::string msg = "";
-  if (level >= _level) {
-    switch (level) {
-      case Level::DEBUG:
-        msg += GRN;
-        msg += "[DEBUG] ";
-        break;
-      case Level::INFO:
-        msg += OFF;
-        msg += "[INFO] ";
-        break;
-      case Level::WARN:
-        msg += YLW;
-        msg += "[WARN] ";
-        break;
-      case Level::ERROR:
-        msg += RED;
-        msg += "[ERROR] ";
-        break;
-      case Level::FATAL:
-        msg += RED;
-        msg += "[FATAL] ";
-        break;
-      default:
-        break;
+void log(logging::Level level, const char* fmt, ...) {
+    std::string msg = "";
+    if (level >= _level) {
+        switch (level) {
+            case Level::DEBUG:
+                msg += GRN;
+                msg += "[DEBUG] ";
+                break;
+            case Level::INFO:
+                msg += OFF;
+                msg += "[INFO] ";
+                break;
+            case Level::WARN:
+                msg += YLW;
+                msg += "[WARN] ";
+                break;
+            case Level::ERROR:
+                msg += RED;
+                msg += "[ERROR] ";
+                break;
+            case Level::FATAL:
+                msg += RED;
+                msg += "[FATAL] ";
+                break;
+            default:
+                break;
+        }
+
+        va_list args;
+        va_start(args, fmt);
+        size_t size = 1024;
+        std::vector<char> dynamicbuf(size);
+        char* buf = &dynamicbuf[0];
+
+        va_list argsTmp;
+
+        while (1) {
+            va_copy(argsTmp, args);
+            int needed = vsnprintf(buf, size, fmt, argsTmp);
+            va_end(argsTmp);
+            if (needed < static_cast<int>(size) - 1 && needed >= 0) {
+                msg.append(buf, static_cast<size_t>(needed));
+                break;
+            }
+            size = needed >= 0 ? needed + 2 : size * 2;
+            dynamicbuf.resize(size);
+            buf = &dynamicbuf[0];
+        }
+        va_end(args);
+        msg.append(END);
+        std::cerr << msg.c_str();
     }
+}
 
-    va_list args;
-    va_start(args, fmt);
-    size_t size = 1024;
-    std::vector<char> dynamicbuf(size);
-    char * buf = &dynamicbuf[0];
+void set_level(Level level) {
+    _level = level;
+    XSLOG_DEBUG("Set logging level to %d.", level);
+}
 
-    va_list argsTmp;
-
-    while (1) {
-      va_copy(argsTmp, args);
-      int needed = vsnprintf(buf, size, fmt, argsTmp);
-      va_end(argsTmp);
-      if (needed < static_cast<int>(size) - 1 && needed >= 0) {
-        msg.append(buf, static_cast<size_t>(needed));
-        break;
-      }
-      size = needed >= 0 ? needed + 2 : size * 2;
-      dynamicbuf.resize(size);
-      buf = &dynamicbuf[0];
+void set_level(std::string level) {
+    if (level == "DEBUG") {
+        set_level(Level::DEBUG);
     }
-    va_end(args);
-    msg.append(END);
-    std::cerr << msg.c_str();
-  }
+    else if (level == "INFO") {
+        set_level(Level::INFO);
+    }
+    else if (level == "WARN") {
+        set_level(Level::WARN);
+    }
+    else if (level == "ERROR") {
+        set_level(Level::ERROR);
+    }
+    else if (level == "FATAL") {
+        set_level(Level::FATAL);
+    }
+    else {
+        XSLOG_ERROR("Tried to set an invalid logging level.");
+    }
 }
 
-void set_level(Level level)
-{
-  _level = level;
-  XSLOG_DEBUG("Set logging level to %d.", level);
-}
-
-void set_level(std::string level)
-{
-  if (level == "DEBUG") {
-    set_level(Level::DEBUG);
-  } else if (level == "INFO") {
-    set_level(Level::INFO);
-  } else if (level == "WARN") {
-    set_level(Level::WARN);
-  } else if (level == "ERROR") {
-    set_level(Level::ERROR);
-  } else if (level == "FATAL") {
-    set_level(Level::FATAL);
-  } else {
-    XSLOG_ERROR("Tried to set an invalid logging level.");
-  }
-}
-
-Level get_level()
-{
-  return _level;
+Level get_level() {
+    return _level;
 }
 
 }  // namespace logging
-
 
 }  // namespace interbotix_xs

--- a/wx_armor/README.md
+++ b/wx_armor/README.md
@@ -5,7 +5,7 @@
    ```bash
    $ nix develop
    ```
-   
+
 2. Build the project
 
    ```bash
@@ -14,37 +14,37 @@
    $ cmake ..
    $ make
    ```
-   
+
 3. Run the built binary
 
    - Make sure the robotic ARM is connected via USB cable
    - Run
-     
+
      ```bash
      $ cd build
      $ ./wx_armor
      ```
-     
+
      And the server will be up and running.
-     
+
 4. Connect to the websocket server and issue command. Below is an example using `websocat`.
 
    ```bash
    $ websocat ws://<ip>:<port>/api/engage
    ```
-   
+
    You can issue command like `SUBSCRIBE`, `SETPOS [<the joint positions>]`, `TORQUE ON`, `TORQUE OFF`, and `SETPID`.
-   
-   The command `SETPID` is in the format of 
-   
+
+   The command `SETPID` is in the format of
+
    ```console
    # Set only the "waist" motor's PID gains
    SETPID [{"name": "waist", "p": 800, "i": 0, "d": 3}]
-   
+
    # Set all motor's PID gains, but "wrist_rotate" will have different value
    SETPID [{"name": "all", "p": 800, "i": 0, "d": 3}, {"name": "wrist_rotate", "p": 400, "i": 0, "d": 0}]
    ```
-     
+
 ## Deployment Guide
 
 This service is normally deployed with systemd on a server. As long as you know the server ip and port, you can connect to the websocket service via the ip and port. Everything should work as expected.

--- a/wx_armor/wx_armor/robot_profile.cc
+++ b/wx_armor/wx_armor/robot_profile.cc
@@ -2,114 +2,113 @@
 
 #include "spdlog/spdlog.h"
 
-namespace YAML {
+namespace YAML
+{
 
-bool convert<horizon::wx_armor::RobotProfile>::decode(
-    const Node &node, horizon::wx_armor::RobotProfile &profile) {
-  using namespace horizon::wx_armor;
+bool convert<horizon::wx_armor::RobotProfile>::decode(const Node& node,
+                                                      horizon::wx_armor::RobotProfile& profile) {
+    using namespace horizon::wx_armor;
 
-  // Fill in model information.
-  for (const auto &child : node["motors"]) {
-    YAML::Node info = child.second;
-    uint8_t motor_id = info["ID"].as<uint8_t>();
+    // Fill in model information.
+    for (const auto& child : node["motors"]) {
+        YAML::Node info = child.second;
+        uint8_t motor_id = info["ID"].as<uint8_t>();
 
-    // Safety velocity limit is given in [deg/s]. Convert it to [rad/s]
-    float safety_vel_limit = info["Safety_Velocity_Limit"].as<float>();
-    safety_vel_limit *= M_PI / 180.;
+        // Safety velocity limit is given in [deg/s]. Convert it to [rad/s]
+        float safety_vel_limit = info["Safety_Velocity_Limit"].as<float>();
+        safety_vel_limit *= M_PI / 180.;
 
-    uint32_t current_limit = info["Current_Limit"].as<uint32_t>();
+        uint32_t current_limit = info["Current_Limit"].as<uint32_t>();
 
-    OpMode op_mode = (current_limit == 0) ? OpMode::POSITION : OpMode::CURRENT_BASED_POSITION;
+        OpMode op_mode = (current_limit == 0) ? OpMode::POSITION : OpMode::CURRENT_BASED_POSITION;
 
-    profile.motors.emplace_back(MotorInfo{
-        .id = motor_id,
-        .name = child.first.as<std::string>(),
-        // By default, set the operation mode to position control.
-        .op_mode = op_mode,
-        .current_limit = current_limit,
-        .safety_vel_limit = safety_vel_limit
-    });
+        profile.motors.emplace_back(
+            MotorInfo{.id = motor_id,
+                      .name = child.first.as<std::string>(),
+                      // By default, set the operation mode to position control.
+                      .op_mode = op_mode,
+                      .current_limit = current_limit,
+                      .safety_vel_limit = safety_vel_limit});
 
-    // Now, populate the register table.
-    for (const auto &kv : info) {
-      std::string key = kv.first.as<std::string>();
-      // Ignore "ID" and "Baud_Rate" as they are not valid register
-      // names on the motor's internal EEPROM register table.
-      if (key == "ID" || key == "Baud_Rate") continue;
-      profile.eeprom.emplace_back(motor_id, key, kv.second.as<int32_t>());
-    }
-  }
-
-  // Fill in joint IDs.
-  for (const auto &child : node["joint_order"]) {
-    std::string name = child.as<std::string>();
-    const MotorInfo *motor = profile.motor(name);
-    if (motor == nullptr) {
-      spdlog::critical(
-          "Malformed motor config. Cannot find a motor named '{}', which "
-          "appears in 'joint_order'",
-          name);
-    }
-    profile.joint_ids.emplace_back(motor->id);
-    profile.joint_names.emplace_back(motor->name);
-  }
-
-  // Handle shadows info. Such info is used to calibrate the homing offsets of
-  // the motors.
-
-  for (const auto &child : node["shadows"]) {
-    // Shadow motors that do not need homing offset calibration are skipped.
-    if (!child.second["calibrate"].as<bool>()) {
-      continue;
+        // Now, populate the register table.
+        for (const auto& kv : info) {
+            std::string key = kv.first.as<std::string>();
+            // Ignore "ID" and "Baud_Rate" as they are not valid register
+            // names on the motor's internal EEPROM register table.
+            if (key == "ID" || key == "Baud_Rate")
+                continue;
+            profile.eeprom.emplace_back(motor_id, key, kv.second.as<int32_t>());
+        }
     }
 
-    std::string master_motor_name = child.first.as<std::string>();
-    MotorInfo *motor =
-        const_cast<MotorInfo *>(profile.motor(master_motor_name));
-
-    if (motor == nullptr) {
-      spdlog::critical(
-          "Malformed motor config. Cannot find a motor named '{}', which "
-          "appears in 'shadows'",
-          master_motor_name);
+    // Fill in joint IDs.
+    for (const auto& child : node["joint_order"]) {
+        std::string name = child.as<std::string>();
+        const MotorInfo* motor = profile.motor(name);
+        if (motor == nullptr) {
+            spdlog::critical("Malformed motor config. Cannot find a motor named '{}', which "
+                             "appears in 'joint_order'",
+                             name);
+        }
+        profile.joint_ids.emplace_back(motor->id);
+        profile.joint_names.emplace_back(motor->name);
     }
 
-    for (const auto &grandchild : child.second["shadow_list"]) {
-      std::string shadow_motor_name = grandchild.as<std::string>();
-      const MotorInfo *shadow_motor = profile.motor(shadow_motor_name);
-      if (motor == nullptr) {
-        spdlog::critical(
-            "Malformed motor config. Cannot find a motor named '{}', which "
-            "appears in 'shadows'",
-            shadow_motor_name);
-      }
-      motor->shadow_motor_ids.emplace_back(shadow_motor->id);
-    }
-  }
+    // Handle shadows info. Such info is used to calibrate the homing offsets of
+    // the motors.
 
-  return true;
+    for (const auto& child : node["shadows"]) {
+        // Shadow motors that do not need homing offset calibration are skipped.
+        if (!child.second["calibrate"].as<bool>()) {
+            continue;
+        }
+
+        std::string master_motor_name = child.first.as<std::string>();
+        MotorInfo* motor = const_cast<MotorInfo*>(profile.motor(master_motor_name));
+
+        if (motor == nullptr) {
+            spdlog::critical("Malformed motor config. Cannot find a motor named '{}', which "
+                             "appears in 'shadows'",
+                             master_motor_name);
+        }
+
+        for (const auto& grandchild : child.second["shadow_list"]) {
+            std::string shadow_motor_name = grandchild.as<std::string>();
+            const MotorInfo* shadow_motor = profile.motor(shadow_motor_name);
+            if (motor == nullptr) {
+                spdlog::critical("Malformed motor config. Cannot find a motor named '{}', "
+                                 "which "
+                                 "appears in 'shadows'",
+                                 shadow_motor_name);
+            }
+            motor->shadow_motor_ids.emplace_back(shadow_motor->id);
+        }
+    }
+
+    return true;
 }
 
 }  // namespace YAML
 
-namespace horizon::wx_armor {
+namespace horizon::wx_armor
+{
 
 std::string_view OpModeName(OpMode mode) {
-  switch (mode) {
-    case OpMode::CURRENT:
-      return "CURRENT";
-    case OpMode::VELOCITY:
-      return "VELOCITY";
-    case OpMode::POSITION:
-      return "POSITION";
-    case OpMode::CURRENT_BASED_POSITION:
-      return "CURRENT_BASED_POSITION";
-    case OpMode::PWM:
-      return "PWM";
-    case OpMode::TORQUE:
-      return "TORQUE";
-  }
-  return "UNKNOWN";
+    switch (mode) {
+        case OpMode::CURRENT:
+            return "CURRENT";
+        case OpMode::VELOCITY:
+            return "VELOCITY";
+        case OpMode::POSITION:
+            return "POSITION";
+        case OpMode::CURRENT_BASED_POSITION:
+            return "CURRENT_BASED_POSITION";
+        case OpMode::PWM:
+            return "PWM";
+        case OpMode::TORQUE:
+            return "TORQUE";
+    }
+    return "UNKNOWN";
 }
 
 }  // namespace horizon::wx_armor

--- a/wx_armor/wx_armor/robot_profile.h
+++ b/wx_armor/wx_armor/robot_profile.h
@@ -24,27 +24,29 @@
 
 #pragma once
 
+#include <math.h>
+
 #include <chrono>
 #include <cstdlib>
 #include <map>
 #include <string_view>
 #include <vector>
-#include <math.h>
 
 #include "yaml-cpp/yaml.h"
 
-namespace horizon::wx_armor {
+namespace horizon::wx_armor
+{
 
 // Enum for the operating mode of the underlying Dynamixel motors. This
 // determines how the underlying controller works and what kind of commands the
 // motor accepts.
 enum class OpMode : int {
-  CURRENT = 0,                 // Electric current controller
-  VELOCITY = 1,                // Velocity controller
-  POSITION = 3,                // Position controller
-  CURRENT_BASED_POSITION = 5,  // Current based position controller
-  PWM = 16,                    // Pulse-width modulation controller
-  TORQUE = 100,                // Torque controller
+    CURRENT = 0,                 // Electric current controller
+    VELOCITY = 1,                // Velocity controller
+    POSITION = 3,                // Position controller
+    CURRENT_BASED_POSITION = 5,  // Current based position controller
+    PWM = 16,                    // Pulse-width modulation controller
+    TORQUE = 100,                // Torque controller
 };
 
 // Convert the OpMode enum to a string e.g. for debugging purpose.
@@ -53,41 +55,44 @@ std::string_view OpModeName(OpMode mode);
 // Stores the metadata of a Dynamixel motor in the robot. Each motor in the
 // robot is associated with an "ID". When communicating with the motors, the
 // APIs use the id to specify which motor they talk to.
-struct MotorInfo {
-  // Dynamixel ID of the motor
-  uint8_t id = 0;
+struct MotorInfo
+{
+    // Dynamixel ID of the motor
+    uint8_t id = 0;
 
-  // Name of the motor.
-  std::string name = "unknown";
+    // Name of the motor.
+    std::string name = "unknown";
 
-  // If the motor is powering the joint together with other shadow motors (which
-  // makes this motor a "master" motor), this is a list of IDs of the
-  // corresponding shadow motors. Otherwise if the motor is powering the joint
-  // alone, this list is empty.
-  std::vector<uint8_t> shadow_motor_ids{};
+    // If the motor is powering the joint together with other shadow motors
+    // (which makes this motor a "master" motor), this is a list of IDs of the
+    // corresponding shadow motors. Otherwise if the motor is powering the joint
+    // alone, this list is empty.
+    std::vector<uint8_t> shadow_motor_ids{};
 
-  // The following information are currently not used at this moment. Having
-  // them here just to be consistent with dynamixel.
-  OpMode op_mode = OpMode::POSITION;
+    // The following information are currently not used at this moment. Having
+    // them here just to be consistent with dynamixel.
+    OpMode op_mode = OpMode::POSITION;
 
-  // The current limit. If it is zero, the motor will be in OpMode::POSITION,
-  // otherwise, it will be in OpMode::CURRENT_BASED_POSITION.
-  uint32_t current_limit = 0;
+    // The current limit. If it is zero, the motor will be in OpMode::POSITION,
+    // otherwise, it will be in OpMode::CURRENT_BASED_POSITION.
+    uint32_t current_limit = 0;
 
-  // The safety velocity limit in [rad/s]
-  float safety_vel_limit = M_PI / 2;
+    // The safety velocity limit in [rad/s]
+    float safety_vel_limit = M_PI / 2;
 };
 
 // The EERPROM area of each motor is logically organized as a few key/value
 // pairs, similar to a registry. This class is used to represent such a
 // key/value pair, together with their associated motor ID.
-struct RegistryKV {
-  uint8_t motor_id;
-  std::string key;
-  int32_t value;
+struct RegistryKV
+{
+    uint8_t motor_id;
+    std::string key;
+    int32_t value;
 
-  RegistryKV(uint8_t motor_id_, const std::string &key_, int32_t value_)
-      : motor_id(motor_id_), key(key_), value(value_) {}
+    RegistryKV(uint8_t motor_id_, const std::string& key_, int32_t value_)
+        : motor_id(motor_id_), key(key_), value(value_) {
+    }
 };
 
 // This class stores the full information about a Dynamixel motor based robot.
@@ -99,38 +104,40 @@ struct RegistryKV {
 //
 // Such information is usually stored in a yaml file. When parsed, the yaml file
 // becomes a RobotProfile instance.
-struct RobotProfile {
-  std::vector<MotorInfo> motors{};
-  std::vector<uint8_t> joint_ids{};
-  std::vector<std::string> joint_names{};
-  std::vector<RegistryKV> eeprom{};
+struct RobotProfile
+{
+    std::vector<MotorInfo> motors{};
+    std::vector<uint8_t> joint_ids{};
+    std::vector<std::string> joint_names{};
+    std::vector<RegistryKV> eeprom{};
 
-  RobotProfile() = default;
-  RobotProfile(RobotProfile &&) = default;
-  RobotProfile &operator=(RobotProfile &) = default;
+    RobotProfile() = default;
+    RobotProfile(RobotProfile&&) = default;
+    RobotProfile& operator=(RobotProfile&) = default;
 
-  // API to access a motor by its name. Returns nullptr if such motor does not
-  // exist in this robot.
-  inline const MotorInfo *motor(const std::string name) const {
-    for (const MotorInfo &entry : motors) {
-      if (entry.name == name) {
-        return &entry;
-      }
+    // API to access a motor by its name. Returns nullptr if such motor does not
+    // exist in this robot.
+    inline const MotorInfo* motor(const std::string name) const {
+        for (const MotorInfo& entry : motors) {
+            if (entry.name == name) {
+                return &entry;
+            }
+        }
+        return nullptr;
     }
-    return nullptr;
-  }
 };
 
 }  // namespace horizon::wx_armor
 
-namespace YAML {
+namespace YAML
+{
 
 // Specialization of YAML::convert for RobotPRofile. so that we can parse yaml
 // into RobotProfile.
 template <>
-struct convert<horizon::wx_armor::RobotProfile> {
-  static bool decode(const Node &node,
-                     horizon::wx_armor::RobotProfile &profile);
+struct convert<horizon::wx_armor::RobotProfile>
+{
+    static bool decode(const Node& node, horizon::wx_armor::RobotProfile& profile);
 };
 
 }  // namespace YAML

--- a/wx_armor/wx_armor/wx_armor.cc
+++ b/wx_armor/wx_armor/wx_armor.cc
@@ -36,12 +36,12 @@ using horizon::wx_armor::WxArmorWebController;
  */
 
 int main(int argc, char** argv) {
-  Driver();  // Ensure driver is up and running.
-  drogon::app()
-      .addListener("0.0.0.0", GetEnv<int>("WX_ARMOR_WS_PORT", 8027))
-      .setClientMaxWebSocketMessageSize(1 * 1024 * 1024 /* 1MB */)
-      .setThreadNum(1)
-      .run();
+    Driver();  // Ensure driver is up and running.
+    drogon::app()
+        .addListener("0.0.0.0", GetEnv<int>("WX_ARMOR_WS_PORT", 8027))
+        .setClientMaxWebSocketMessageSize(1 * 1024 * 1024 /* 1MB */)
+        .setThreadNum(1)
+        .run();
 
-  return 0;
+    return 0;
 }

--- a/wx_armor/wx_armor/wx_armor_driver.cc
+++ b/wx_armor/wx_armor/wx_armor_driver.cc
@@ -9,28 +9,29 @@
 
 namespace fs = std::filesystem;
 
-namespace horizon::wx_armor {
-namespace {
+namespace horizon::wx_armor
+{
+namespace
+{
 
 static constexpr uint32_t DEFAULT_BAUDRATE = 1'000'000;
 
 // Load the configuration file, which should be in YAML format. Upon failure,
 // crash the program.
 auto LoadConfigOrDie(fs::path config_path) -> YAML::Node {
-  try {
-    YAML::Node node = YAML::LoadFile(config_path.c_str());
-    if (node.IsNull()) {
-      spdlog::critical("Failed to read config file {} as it is empty.",
-                       config_path.string());
-      std::abort();
+    try {
+        YAML::Node node = YAML::LoadFile(config_path.c_str());
+        if (node.IsNull()) {
+            spdlog::critical("Failed to read config file {} as it is empty.", config_path.string());
+            std::abort();
+        }
+        return node;
     }
-    return node;
-  } catch (YAML::BadFile &error) {
-    spdlog::critical("Failed to load the config file {}, due to {}",
-                     config_path.string(),
-                     error.what());
-    std::abort();
-  }
+    catch (YAML::BadFile& error) {
+        spdlog::critical("Failed to load the config file {}, due to {}", config_path.string(),
+                         error.what());
+        std::abort();
+    }
 }
 
 // The driver is a long running service. There are cases that when the driver
@@ -38,175 +39,162 @@ auto LoadConfigOrDie(fs::path config_path) -> YAML::Node {
 // failure) the USB cable connecting the arm (U2D2) and the runnig host (usually
 // a Raspberry Pi) isn't plugged in yet. In this case the driver will be waiting
 // for the port to get ready (i.e. for the cable to be plugged in).
-void WaitUntilPortAvailable(DynamixelWorkbench *dxl_wb,
-                            const std::string usb_port) {
-  spdlog::info("Still waiting for USB port {} to be available ...", usb_port);
-  while (true) {
-    // Note that for WidowX 250s, if we do not use the default Baudrate 1000000,
-    // the communication between the driver and the robotic arm WILL NOT work.
-    bool success = dxl_wb->init(usb_port.c_str(), DEFAULT_BAUDRATE);
-    if (success) {
-      break;
+void WaitUntilPortAvailable(DynamixelWorkbench* dxl_wb, const std::string usb_port) {
+    spdlog::info("Still waiting for USB port {} to be available ...", usb_port);
+    while (true) {
+        // Note that for WidowX 250s, if we do not use the default Baudrate
+        // 1000000, the communication between the driver and the robotic arm
+        // WILL NOT work.
+        bool success = dxl_wb->init(usb_port.c_str(), DEFAULT_BAUDRATE);
+        if (success) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::seconds(1));
     }
-    std::this_thread::sleep_for(std::chrono::seconds(1));
-  }
-  spdlog::info("Successfully connected to {}", usb_port);
+    spdlog::info("Successfully connected to {}", usb_port);
 }
 
 // This makes sure that all the motors defined in the robot profile are
 // reachable. Returns `false` if not all of them are reachable.
-auto PingMotors(DynamixelWorkbench *dxl_wb,
-                const RobotProfile &profile,
-                bool log_errors_only = false,
-                int num_trials = 3,
-                std::chrono::milliseconds sleep_between_trials =
-                    std::chrono::milliseconds(200)) -> bool {
-  const char *log;
+auto PingMotors(DynamixelWorkbench* dxl_wb, const RobotProfile& profile,
+                bool log_errors_only = false, int num_trials = 3,
+                std::chrono::milliseconds sleep_between_trials = std::chrono::milliseconds(200))
+    -> bool {
+    const char* log;
 
-  std::set<uint8_t> success{};
+    std::set<uint8_t> success{};
 
-  for (int i = 0; i < num_trials; ++i) {
-    for (const MotorInfo &motor : profile.motors) {
-      if (success.count(motor.id) > 0) continue;
-      if (dxl_wb->ping(motor.id, &log)) {
-        success.emplace(motor.id);
-        if (log_errors_only) {
-          continue;
+    for (int i = 0; i < num_trials; ++i) {
+        for (const MotorInfo& motor : profile.motors) {
+            if (success.count(motor.id) > 0)
+                continue;
+            if (dxl_wb->ping(motor.id, &log)) {
+                success.emplace(motor.id);
+                if (log_errors_only) {
+                    continue;
+                }
+                std::string model_name = dxl_wb->getModelName(motor.id);
+                spdlog::info("Found DYNAMIXEL Motor ID: {}, Model: {}, Name: {}", motor.id,
+                             model_name, motor.name);
+                if (model_name == "XL-320") {
+                    spdlog::warn("Model XL-320's current reading is not supported by "
+                                 "this "
+                                 "driver, because its effort is load (%) based.");
+                }
+            }
+            else {
+                spdlog::error("FAILED to ping Motor ID: {}, Name: {}", motor.id, motor.name);
+                break;
+            }
         }
-        std::string model_name = dxl_wb->getModelName(motor.id);
-        spdlog::info("Found DYNAMIXEL Motor ID: {}, Model: {}, Name: {}",
-                     motor.id,
-                     model_name,
-                     motor.name);
-        if (model_name == "XL-320") {
-          spdlog::warn(
-              "Model XL-320's current reading is not supported by this "
-              "driver, because its effort is load (%) based.");
+        if (success.size() == profile.motors.size()) {
+            return true;
         }
-      } else {
-        spdlog::error(
-            "FAILED to ping Motor ID: {}, Name: {}", motor.id, motor.name);
-        break;
-      }
+        else if (i + 1 < num_trials) {
+            if (!log_errors_only) {
+                spdlog::warn("Found only {} / {} motors. Will wait for {} ms and retry.",
+                             success.size(), profile.motors.size(), sleep_between_trials.count());
+            }
+            std::this_thread::sleep_for(sleep_between_trials);
+        }
     }
-    if (success.size() == profile.motors.size()) {
-      return true;
-    } else if (i + 1 < num_trials) {
-      if (!log_errors_only) {
-        spdlog::warn("Found only {} / {} motors. Will wait for {} ms and retry.",
-                     success.size(),
-                     profile.motors.size(),
-                     sleep_between_trials.count());
-      }
-      std::this_thread::sleep_for(sleep_between_trials);
-    }
-  }
-  return false;
+    return false;
 }
 
-void FlashEEPROM(DynamixelWorkbench *dxl_wb, const RobotProfile &profile) {
-  const char *log;
+void FlashEEPROM(DynamixelWorkbench* dxl_wb, const RobotProfile& profile) {
+    const char* log;
 
-  size_t num_failed = 0;
-  for (const RegistryKV &kv : profile.eeprom) {
-    int32_t current_value = 0;
+    size_t num_failed = 0;
+    for (const RegistryKV& kv : profile.eeprom) {
+        int32_t current_value = 0;
 
-    // Hacky fix for now... Probably a better way to handle this
-    // Safety_Velocity_Limit is our own custom param. Don't write it to EEPROM
-    if (kv.key == "Safety_Velocity_Limit" || kv.key == "Current_Limit") {
-      continue;
+        // Hacky fix for now... Probably a better way to handle this
+        // Safety_Velocity_Limit is our own custom param. Don't write it to
+        // EEPROM
+        if (kv.key == "Safety_Velocity_Limit" || kv.key == "Current_Limit") {
+            continue;
+        }
+        dxl_wb->itemRead(kv.motor_id, kv.key.c_str(), &current_value);
+
+        // The EEPROM on the motors has a limited number of writes during its
+        // lifespan. Only write when there is a discrepancy between the intended
+        // value and the current value.
+        if (current_value == kv.value) {
+            continue;
+        }
+
+        if (!dxl_wb->itemWrite(kv.motor_id, kv.key.c_str(), kv.value, &log)) {
+            spdlog::error("Failed to flash EEPROM for key value pair ({}, {}) on motor "
+                          "ID = "
+                          "{}: {}",
+                          kv.key, kv.value, kv.motor_id, log);
+            ++num_failed;
+        }
+        else {
+            spdlog::info("Value '{}' of Motor {} is set to {}.", kv.key, kv.motor_id, kv.value);
+        }
     }
-    dxl_wb->itemRead(kv.motor_id, kv.key.c_str(), &current_value);
 
-    // The EEPROM on the motors has a limited number of writes during its
-    // lifespan. Only write when there is a discrepancy between the intended
-    // value and the current value.
-    if (current_value == kv.value) {
-      continue;
+    if (num_failed > 0) {
+        spdlog::critical("Failed to flash all registry key value pairs to EEPROM (failure "
+                         "{} / {}).",
+                         num_failed, profile.eeprom.size());
+        std::abort();
     }
-
-    if (!dxl_wb->itemWrite(kv.motor_id, kv.key.c_str(), kv.value, &log)) {
-      spdlog::error(
-          "Failed to flash EEPROM for key value pair ({}, {}) on motor ID = "
-          "{}: {}",
-          kv.key,
-          kv.value,
-          kv.motor_id,
-          log);
-      ++num_failed;
-    } else {
-      spdlog::info("Value '{}' of Motor {} is set to {}.",
-                   kv.key,
-                   kv.motor_id,
-                   kv.value);
+    else {
+        spdlog::info("Successfully flashed all registry key value pairs to EEPROM.");
     }
-  }
-
-  if (num_failed > 0) {
-    spdlog::critical(
-        "Failed to flash all registry key value pairs to EEPROM (failure "
-        "{} / {}).",
-        num_failed,
-        profile.eeprom.size());
-    std::abort();
-  } else {
-    spdlog::info(
-        "Successfully flashed all registry key value pairs to EEPROM.");
-  }
 }
 
 // Calibrate the shadow motors so that their 0 position is identical to the 0
 // position of their corresponding master motor. This is done by setting the
 // homing offset of the shadow motors.
-void CalibrateShadowOrDie(DynamixelWorkbench *dxl_wb,
-                          const RobotProfile &profile) {
-  for (const MotorInfo &motor : profile.motors) {
-    // Skip the motor that does not have any shadow motors to calibrate.
-    if (motor.shadow_motor_ids.empty()) {
-      continue;
+void CalibrateShadowOrDie(DynamixelWorkbench* dxl_wb, const RobotProfile& profile) {
+    for (const MotorInfo& motor : profile.motors) {
+        // Skip the motor that does not have any shadow motors to calibrate.
+        if (motor.shadow_motor_ids.empty()) {
+            continue;
+        }
+
+        int32_t master_position = 0;
+        dxl_wb->itemRead(motor.id, "Present_Position", &master_position);
+
+        for (int32_t shadow_id : motor.shadow_motor_ids) {
+            // In order to read the baseline shadow position without homing
+            // offset, first set the homing offset to 0.
+            if (!dxl_wb->itemWrite(shadow_id, "Homing_Offset", 0)) {
+                spdlog::critical("Failed to reset homing offset of motor {} to 0.", shadow_id);
+                std::abort();
+            }
+
+            int32_t shadow_position = 0;
+            int32_t shadow_drive_mode = 0;
+            dxl_wb->itemRead(shadow_id, "Present_Position", &shadow_position);
+            dxl_wb->itemRead(shadow_id, "Drive_Mode", &shadow_drive_mode);
+
+            // Now we are going to look at the 1st bit of the drive mode, which
+            // determines whether the motor is in Normal Mode or Reverse Mode.
+            //
+            // drive_mode & 1 == 0, Normal Mode, position⇧ = rotate CCW
+            //
+            // drive_mode & 1 == 1, Reverse Mode, position⇧ = rotate CW
+            int32_t homing_offset = ((shadow_drive_mode & 1) == 1)
+                                        ? shadow_position - master_position
+                                        : master_position - shadow_position;
+            if (!dxl_wb->itemWrite(shadow_id, "Homing_Offset", homing_offset)) {
+                spdlog::critical("Failed to write homing offset of motor {} during shadow "
+                                 "motor "
+                                 "calibration",
+                                 shadow_id);
+                std::abort();
+            }
+            else {
+                spdlog::info("Successfully calibrated motor {} and {} with homing "
+                             "offset = {}",
+                             motor.id, shadow_id, homing_offset);
+            }
+        }
     }
-
-    int32_t master_position = 0;
-    dxl_wb->itemRead(motor.id, "Present_Position", &master_position);
-
-    for (int32_t shadow_id : motor.shadow_motor_ids) {
-      // In order to read the baseline shadow position without homing
-      // offset, first set the homing offset to 0.
-      if (!dxl_wb->itemWrite(shadow_id, "Homing_Offset", 0)) {
-        spdlog::critical("Failed to reset homing offset of motor {} to 0.",
-                         shadow_id);
-        std::abort();
-      }
-
-      int32_t shadow_position = 0;
-      int32_t shadow_drive_mode = 0;
-      dxl_wb->itemRead(shadow_id, "Present_Position", &shadow_position);
-      dxl_wb->itemRead(shadow_id, "Drive_Mode", &shadow_drive_mode);
-
-      // Now we are going to look at the 1st bit of the drive mode, which
-      // determines whether the motor is in Normal Mode or Reverse Mode.
-      //
-      // drive_mode & 1 == 0, Normal Mode, position⇧ = rotate CCW
-      //
-      // drive_mode & 1 == 1, Reverse Mode, position⇧ = rotate CW
-      int32_t homing_offset = ((shadow_drive_mode & 1) == 1)
-                                  ? shadow_position - master_position
-                                  : master_position - shadow_position;
-      if (!dxl_wb->itemWrite(shadow_id, "Homing_Offset", homing_offset)) {
-        spdlog::critical(
-            "Failed to write homing offset of motor {} during shadow motor "
-            "calibration",
-            shadow_id);
-        std::abort();
-      } else {
-        spdlog::info(
-            "Successfully calibrated motor {} and {} with homing offset = {}",
-            motor.id,
-            shadow_id,
-            homing_offset);
-      }
-    }
-  }
 }
 
 // Set the current limit of each motor. The current limit effectively determines
@@ -224,468 +212,429 @@ void CalibrateShadowOrDie(DynamixelWorkbench *dxl_wb,
 // limit. The XL-series motors will still be under "position control" mode.
 //
 // The WidowX 250s robotic arm has 7 XM-series motors and 2-XL series motors.
-void SetCurrentLimit(DynamixelWorkbench *dxl_wb,
-                     RobotProfile *profile) {
-  const char *log = nullptr;
+void SetCurrentLimit(DynamixelWorkbench* dxl_wb, RobotProfile* profile) {
+    const char* log = nullptr;
 
-  for (MotorInfo &motor : profile->motors) {
-    std::string model_name = dxl_wb->getModelName(motor.id);
-    uint32_t current_limit = motor.current_limit;
+    for (MotorInfo& motor : profile->motors) {
+        std::string model_name = dxl_wb->getModelName(motor.id);
+        uint32_t current_limit = motor.current_limit;
 
-    // If the current limit (effectively torque limit) is set to a non-zero
-    // value, we should use current-based position controller as the operation
-    // mode, so that we can set current limit to the motor.
-    //
-    // There is one exception. If the motor is an XL series motor, it does
-    // support current-based position controller operation mode. In this case,
-    // we are still going to use the default position controller operation mode.
-    if (current_limit == 0 || model_name.substr(0, 2) == "XL") {
-      motor.op_mode = OpMode::POSITION;
-      if (!dxl_wb->setPositionControlMode(motor.id, &log)) {
-        spdlog::critical(
-            "Failed to set OpMode to POSITION on motor {} (id = {}): {}",
-            motor.name,
-            motor.id,
-            log);
-        std::abort();
-      }
-    } else {
-      motor.op_mode = OpMode::CURRENT_BASED_POSITION;
-      if (!dxl_wb->currentBasedPositionMode(motor.id, current_limit, &log)) {
-        spdlog::critical(
-            "Failed to set OpMode to POSITION on motor {} (id = {}): {}",
-            motor.name,
-            motor.id,
-            log);
-        std::abort();
-      }
+        // If the current limit (effectively torque limit) is set to a non-zero
+        // value, we should use current-based position controller as the
+        // operation mode, so that we can set current limit to the motor.
+        //
+        // There is one exception. If the motor is an XL series motor, it does
+        // support current-based position controller operation mode. In this
+        // case, we are still going to use the default position controller
+        // operation mode.
+        if (current_limit == 0 || model_name.substr(0, 2) == "XL") {
+            motor.op_mode = OpMode::POSITION;
+            if (!dxl_wb->setPositionControlMode(motor.id, &log)) {
+                spdlog::critical("Failed to set OpMode to POSITION on motor {} (id = {}): "
+                                 "{}",
+                                 motor.name, motor.id, log);
+                std::abort();
+            }
+        }
+        else {
+            motor.op_mode = OpMode::CURRENT_BASED_POSITION;
+            if (!dxl_wb->currentBasedPositionMode(motor.id, current_limit, &log)) {
+                spdlog::critical("Failed to set OpMode to POSITION on motor {} (id = {}): "
+                                 "{}",
+                                 motor.name, motor.id, log);
+                std::abort();
+            }
+        }
+        spdlog::info("Successfully set OpMode to {} on motor {} (id = {})",
+                     OpModeName(motor.op_mode), motor.name, motor.id);
     }
-    spdlog::info("Successfully set OpMode to {} on motor {} (id = {})",
-                 OpModeName(motor.op_mode),
-                 motor.name,
-                 motor.id);
-  }
 }
 
 // Check all the motors and see whether there are motors in error state. If so,
 // that motor is rebooted. This function is called at initialization.
-void RebootMotorIfInErrorState(DynamixelWorkbench *dxl_wb,
-                               const RobotProfile &profile) {
-  const char *log;
-  int32_t value = 0;
-  for (const MotorInfo &motor : profile.motors) {
-    bool success =
-        dxl_wb->itemRead(motor.id, "Hardware_Error_Status", &value, &log);
+void RebootMotorIfInErrorState(DynamixelWorkbench* dxl_wb, const RobotProfile& profile) {
+    const char* log;
+    int32_t value = 0;
+    for (const MotorInfo& motor : profile.motors) {
+        bool success = dxl_wb->itemRead(motor.id, "Hardware_Error_Status", &value, &log);
 
-    if (success && value == 0) {
-      continue;
-    } else if (dxl_wb->reboot(motor.id, &log)) {
-      spdlog::info("Motor {} '{}' was in error state, and is rebooted.",
-                   motor.id,
-                   motor.name);
-    } else {
-      spdlog::critical(
-          "Motor {} '{}' was in error state, but fail to reboot it: {}",
-          motor.id,
-          motor.name,
-          log);
-      std::abort();
+        if (success && value == 0) {
+            continue;
+        }
+        else if (dxl_wb->reboot(motor.id, &log)) {
+            spdlog::info("Motor {} '{}' was in error state, and is rebooted.", motor.id,
+                         motor.name);
+        }
+        else {
+            spdlog::critical("Motor {} '{}' was in error state, but fail to reboot it: {}",
+                             motor.id, motor.name, log);
+            std::abort();
+        }
     }
-  }
 }
 
 }  // namespace
 
-WxArmorDriver::WxArmorDriver(const std::string &usb_port,
-                             fs::path motor_config_path,
+WxArmorDriver::WxArmorDriver(const std::string& usb_port, fs::path motor_config_path,
                              bool flash_eeprom)
     : profile_(LoadConfigOrDie(motor_config_path).as<RobotProfile>()) {
-  WaitUntilPortAvailable(&dxl_wb_, usb_port);
+    WaitUntilPortAvailable(&dxl_wb_, usb_port);
 
-  if (dxl_wb_.getProtocolVersion() != 2.0) {
-    spdlog::critical("Requires protocol 2.0, but got {:.1f}",
-                     dxl_wb_.getProtocolVersion());
-  }
+    if (dxl_wb_.getProtocolVersion() != 2.0) {
+        spdlog::critical("Requires protocol 2.0, but got {:.1f}", dxl_wb_.getProtocolVersion());
+    }
 
-  // For WindowX 250s, we are expecting 9 motors
-  //
-  // Found DYNAMIXEL Motor ID: 1, Model: XM430-W350, Name: waist
-  // Found DYNAMIXEL Motor ID: 2, Model: XM430-W350, Name: shoulder
-  // Found DYNAMIXEL Motor ID: 3, Model: XM430-W350, Name: shoulder_shadow
-  // Found DYNAMIXEL Motor ID: 4, Model: XM430-W350, Name: elbow
-  // Found DYNAMIXEL Motor ID: 5, Model: XM430-W350, Name: elbow_shadow
-  // Found DYNAMIXEL Motor ID: 6, Model: XM430-W350, Name: forearm_roll
-  // Found DYNAMIXEL Motor ID: 7, Model: XM430-W350, Name: wrist_angle
-  // Found DYNAMIXEL Motor ID: 8, Model: XL430-W250, Name: wrist_rotate
-  // Found DYNAMIXEL Motor ID: 9, Model: XL430-W250, Name: gripper
-  while (!PingMotors(&dxl_wb_, profile_)) {
-    spdlog::critical("Could not find all specified motors.");
-    std::this_thread::sleep_for(std::chrono::seconds(3));
-  }
+    // For WindowX 250s, we are expecting 9 motors
+    //
+    // Found DYNAMIXEL Motor ID: 1, Model: XM430-W350, Name: waist
+    // Found DYNAMIXEL Motor ID: 2, Model: XM430-W350, Name: shoulder
+    // Found DYNAMIXEL Motor ID: 3, Model: XM430-W350, Name: shoulder_shadow
+    // Found DYNAMIXEL Motor ID: 4, Model: XM430-W350, Name: elbow
+    // Found DYNAMIXEL Motor ID: 5, Model: XM430-W350, Name: elbow_shadow
+    // Found DYNAMIXEL Motor ID: 6, Model: XM430-W350, Name: forearm_roll
+    // Found DYNAMIXEL Motor ID: 7, Model: XM430-W350, Name: wrist_angle
+    // Found DYNAMIXEL Motor ID: 8, Model: XL430-W250, Name: wrist_rotate
+    // Found DYNAMIXEL Motor ID: 9, Model: XL430-W250, Name: gripper
+    while (!PingMotors(&dxl_wb_, profile_)) {
+        spdlog::critical("Could not find all specified motors.");
+        std::this_thread::sleep_for(std::chrono::seconds(3));
+    }
 
-  // Torque off so that we can write EEPROM, calibrate shadow motors and so on.
-  TorqueOff();
+    // Torque off so that we can write EEPROM, calibrate shadow motors and so
+    // on.
+    TorqueOff();
 
-  RebootMotorIfInErrorState(&dxl_wb_, profile_);
-  if (flash_eeprom) {
-    // Note that FlashEEPROM performs "write-on-diff", meaning that it will not
-    // write if the desired value and current value are the same. This can
-    // effectively extend the lifespan of the EEPROM because it has limited
-    // number of writes.
-    FlashEEPROM(&dxl_wb_, profile_);
-  }
-  CalibrateShadowOrDie(&dxl_wb_, profile_);
-  SetCurrentLimit(&dxl_wb_, &profile_);
+    RebootMotorIfInErrorState(&dxl_wb_, profile_);
+    if (flash_eeprom) {
+        // Note that FlashEEPROM performs "write-on-diff", meaning that it will
+        // not write if the desired value and current value are the same. This
+        // can effectively extend the lifespan of the EEPROM because it has
+        // limited number of writes.
+        FlashEEPROM(&dxl_wb_, profile_);
+    }
+    CalibrateShadowOrDie(&dxl_wb_, profile_);
+    SetCurrentLimit(&dxl_wb_, &profile_);
 
-  // Now torque back on.
-  TorqueOn();
+    // Now torque back on.
+    TorqueOn();
 
-  InitReadHandler();
-  InitWriteHandler();
+    InitReadHandler();
+    InitWriteHandler();
 }
 
-WxArmorDriver::~WxArmorDriver() {}
+WxArmorDriver::~WxArmorDriver() {
+}
 
 bool WxArmorDriver::MotorHealthCheck() {
-  std::unique_lock<std::mutex> handler_lock{io_mutex_};
-  return PingMotors(&dxl_wb_, profile_, /* log_errors_only */ true,
-                    /* num_trials */ 1);
+    std::unique_lock<std::mutex> handler_lock{io_mutex_};
+    return PingMotors(&dxl_wb_, profile_,
+                      /* log_errors_only */ true,
+                      /* num_trials */ 1);
 }
 
 std::optional<SensorData> WxArmorDriver::Read() {
-  static uint64_t error_count = 0;
-  std::vector<int32_t> buffer(profile_.joint_ids.size());
-  const uint8_t num_joints = static_cast<uint8_t>(buffer.size());
+    static uint64_t error_count = 0;
+    std::vector<int32_t> buffer(profile_.joint_ids.size());
+    const uint8_t num_joints = static_cast<uint8_t>(buffer.size());
 
-  SensorData result = SensorData{
-      .pos = std::vector<float>(num_joints),
-      .vel = std::vector<float>(num_joints),
-      .crt = std::vector<float>(num_joints),
-      .err = std::vector<uint32_t>(num_joints),
-  };
+    SensorData result = SensorData{
+        .pos = std::vector<float>(num_joints),
+        .vel = std::vector<float>(num_joints),
+        .crt = std::vector<float>(num_joints),
+        .err = std::vector<uint32_t>(num_joints),
+    };
 
-  std::unique_lock<std::mutex> handler_lock{io_mutex_};
-  const char *log;
+    std::unique_lock<std::mutex> handler_lock{io_mutex_};
+    const char* log;
 
-  if (!dxl_wb_.syncRead(
-          read_handler_index_, profile_.joint_ids.data(), num_joints, &log)) {
-    if (error_count % 1000 == 0) {
-      spdlog::warn("Failed to syncRead: {}", log);
+    if (!dxl_wb_.syncRead(read_handler_index_, profile_.joint_ids.data(), num_joints, &log)) {
+        if (error_count % 1000 == 0) {
+            spdlog::warn("Failed to syncRead: {}", log);
+        }
+        ++error_count;
+        return std::nullopt;
     }
-    ++error_count;
-    return std::nullopt;
-  } else {
-    error_count = 0;
-  }
+    else {
+        error_count = 0;
+    }
 
-  // We use the time here as the timestamp for the latest reading. This is,
-  // however, an approximation. It won't be much off because the syncRead above
-  // typically takes 2ms to complete.
-  result.timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(
-                         std::chrono::system_clock::now().time_since_epoch())
-                         .count();
+    // We use the time here as the timestamp for the latest reading. This is,
+    // however, an approximation. It won't be much off because the syncRead
+    // above typically takes 2ms to complete.
+    result.timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(
+                           std::chrono::system_clock::now().time_since_epoch())
+                           .count();
 
-  // 1. Extract Position
+    // 1. Extract Position
 
-  if (!dxl_wb_.getSyncReadData(read_handler_index_,
-                               profile_.joint_ids.data(),
-                               num_joints,
-                               read_position_address_.address,
-                               read_position_address_.data_length,
-                               buffer.data(),
-                               &log)) {
-    spdlog::critical("Cannot getSyncReadData (position): {}", log);
-    std::abort();
-  }
+    if (!dxl_wb_.getSyncReadData(read_handler_index_, profile_.joint_ids.data(), num_joints,
+                                 read_position_address_.address, read_position_address_.data_length,
+                                 buffer.data(), &log)) {
+        spdlog::critical("Cannot getSyncReadData (position): {}", log);
+        std::abort();
+    }
 
-  for (size_t i = 0; i < profile_.joint_ids.size(); ++i) {
-    result.pos[i] =
-        dxl_wb_.convertValue2Radian(profile_.joint_ids[i], buffer[i]);
-  }
+    for (size_t i = 0; i < profile_.joint_ids.size(); ++i) {
+        result.pos[i] = dxl_wb_.convertValue2Radian(profile_.joint_ids[i], buffer[i]);
+    }
 
-  // 2. Extract Velocity
+    // 2. Extract Velocity
 
-  if (!dxl_wb_.getSyncReadData(read_handler_index_,
-                               profile_.joint_ids.data(),
-                               num_joints,
-                               read_velocity_address_.address,
-                               read_velocity_address_.data_length,
-                               buffer.data(),
-                               &log)) {
-    spdlog::critical("Cannot getSyncReadData (velocity): {}", log);
-    std::abort();
-  }
+    if (!dxl_wb_.getSyncReadData(read_handler_index_, profile_.joint_ids.data(), num_joints,
+                                 read_velocity_address_.address, read_velocity_address_.data_length,
+                                 buffer.data(), &log)) {
+        spdlog::critical("Cannot getSyncReadData (velocity): {}", log);
+        std::abort();
+    }
 
-  for (size_t i = 0; i < profile_.joint_ids.size(); ++i) {
-    result.vel[i] =
-        dxl_wb_.convertValue2Velocity(profile_.joint_ids[i], buffer[i]);
-  }
+    for (size_t i = 0; i < profile_.joint_ids.size(); ++i) {
+        result.vel[i] = dxl_wb_.convertValue2Velocity(profile_.joint_ids[i], buffer[i]);
+    }
 
-  // 3. Extract Current
+    // 3. Extract Current
 
-  if (!dxl_wb_.getSyncReadData(read_handler_index_,
-                               profile_.joint_ids.data(),
-                               num_joints,
-                               read_current_address_.address,
-                               read_current_address_.data_length,
-                               buffer.data(),
-                               &log)) {
-    spdlog::critical("Cannot getSyncReadData (current): {}", log);
-    std::abort();
-  }
+    if (!dxl_wb_.getSyncReadData(read_handler_index_, profile_.joint_ids.data(), num_joints,
+                                 read_current_address_.address, read_current_address_.data_length,
+                                 buffer.data(), &log)) {
+        spdlog::critical("Cannot getSyncReadData (current): {}", log);
+        std::abort();
+    }
 
-  for (size_t i = 0; i < profile_.joint_ids.size(); ++i) {
-    result.crt[i] =
-        dxl_wb_.convertValue2Current(profile_.joint_ids[i], buffer[i]);
-  }
+    for (size_t i = 0; i < profile_.joint_ids.size(); ++i) {
+        result.crt[i] = dxl_wb_.convertValue2Current(profile_.joint_ids[i], buffer[i]);
+    }
 
-  return std::move(result);
+    return std::move(result);
 }
 
 std::vector<float> WxArmorDriver::GetSafetyVelocityLimits() {
-  std::vector<float> safety_velocity_limits;
+    std::vector<float> safety_velocity_limits;
 
-  int counter = 0;
-  for (const auto &motor : profile_.motors) {
-    // Skip the shadowed motors, which have IDs 3 and 5.
-    if (counter != 3 && counter != 5) {
-      safety_velocity_limits.push_back(motor.safety_vel_limit);
+    int counter = 0;
+    for (const auto& motor : profile_.motors) {
+        // Skip the shadowed motors, which have IDs 3 and 5.
+        if (counter != 3 && counter != 5) {
+            safety_velocity_limits.push_back(motor.safety_vel_limit);
+        }
+        counter++;
     }
-    counter++;
-  }
-  return safety_velocity_limits;
+    return safety_velocity_limits;
 }
 
 std::vector<float> WxArmorDriver::GetSafetyCurrentLimits() {
-  std::vector<float> safety_current_limits;
+    std::vector<float> safety_current_limits;
 
-  for (const auto &motor : profile_.motors) {
-    float limit = motor.current_limit;
-    if (limit < 1) {
-      limit = 1200;
+    for (const auto& motor : profile_.motors) {
+        float limit = motor.current_limit;
+        if (limit < 1) {
+            limit = 1200;
+        }
+        safety_current_limits.push_back(limit);
     }
-    safety_current_limits.push_back(limit);
-  }
-  return safety_current_limits;
+    return safety_current_limits;
 }
 
-void WxArmorDriver::SetPosition(const std::vector<float> &position,
-                                float moving_time,
+void WxArmorDriver::SetPosition(const std::vector<float>& position, float moving_time,
                                 float acc_time) {
-  assert(moving_time / 2 >= acc_time &&
-         "Acceleration time cannot be more than half the moving time.");
+    assert(moving_time / 2 >= acc_time &&
+           "Acceleration time cannot be more than half the moving time.");
 
-  int32_t moving_time_ms = static_cast<int32_t>(moving_time * 1000.0);
-  int32_t acc_time_ms = static_cast<int32_t>(acc_time * 1000.0);
-  const uint8_t num_joints = static_cast<uint8_t>(profile_.joint_ids.size());
-  std::vector<int32_t> int_command(num_joints * 3, 0);
-  size_t j = 0;
-  for (size_t i = 0; i < profile_.joint_ids.size(); ++i) {
-    // Profile acceleration
-    int_command[j++] = acc_time_ms;
-    // Profile velocity
-    int_command[j++] = moving_time_ms;
-    // Goal Position
-    int_command[j++] =
-        dxl_wb_.convertRadian2Value(profile_.joint_ids[i], position.at(i));
-  }
+    int32_t moving_time_ms = static_cast<int32_t>(moving_time * 1000.0);
+    int32_t acc_time_ms = static_cast<int32_t>(acc_time * 1000.0);
+    const uint8_t num_joints = static_cast<uint8_t>(profile_.joint_ids.size());
+    std::vector<int32_t> int_command(num_joints * 3, 0);
+    size_t j = 0;
+    for (size_t i = 0; i < profile_.joint_ids.size(); ++i) {
+        // Profile acceleration
+        int_command[j++] = acc_time_ms;
+        // Profile velocity
+        int_command[j++] = moving_time_ms;
+        // Goal Position
+        int_command[j++] = dxl_wb_.convertRadian2Value(profile_.joint_ids[i], position.at(i));
+    }
 
-  const char *log = nullptr;
-  std::unique_lock<std::mutex> lock{io_mutex_};
+    const char* log = nullptr;
+    std::unique_lock<std::mutex> lock{io_mutex_};
 
-  // NOTE: The number of data for each motor (= 1) in this call to syncWrite()
-  // means that each motor will take one int32_t value from int_command.data().
-  bool success = dxl_wb_.syncWrite(write_position_and_profile_handler_index_,
-                                   profile_.joint_ids.data(),
-                                   num_joints,
-                                   int_command.data(),
-                                   3, /* number of data for each motor */
-                                   &log);
-  lock.unlock();
-  if (!success) {
-    spdlog::error("Cannot write position command: {}", log);
-  }
+    // NOTE: The number of data for each motor (= 1) in this call to syncWrite()
+    // means that each motor will take one int32_t value from
+    // int_command.data().
+    bool success =
+        dxl_wb_.syncWrite(write_position_and_profile_handler_index_, profile_.joint_ids.data(),
+                          num_joints, int_command.data(), 3, /* number of data for each motor */
+                          &log);
+    lock.unlock();
+    if (!success) {
+        spdlog::error("Cannot write position command: {}", log);
+    }
 }
 
 void WxArmorDriver::TorqueOn() {
-  std::lock_guard<std::mutex> lock{io_mutex_};
-  for (const MotorInfo &motor : profile_.motors) {
-    dxl_wb_.torqueOn(motor.id);
-  }
+    std::lock_guard<std::mutex> lock{io_mutex_};
+    for (const MotorInfo& motor : profile_.motors) {
+        dxl_wb_.torqueOn(motor.id);
+    }
 }
 
 void WxArmorDriver::TorqueOff() {
-  std::lock_guard<std::mutex> lock{io_mutex_};
-  for (const MotorInfo &motor : profile_.motors) {
-    dxl_wb_.torqueOff(motor.id);
-  }
+    std::lock_guard<std::mutex> lock{io_mutex_};
+    for (const MotorInfo& motor : profile_.motors) {
+        dxl_wb_.torqueOff(motor.id);
+    }
 }
 
-void WxArmorDriver::SetPID(const std::vector<PIDGain> &gain_cfgs) {
-  std::lock_guard<std::mutex> lock{io_mutex_};
+void WxArmorDriver::SetPID(const std::vector<PIDGain>& gain_cfgs) {
+    std::lock_guard<std::mutex> lock{io_mutex_};
 
-  auto SetPIDSingleMotor =
-      [this](uint8_t motor_id, int32_t p, int32_t i, int32_t d) -> void {
-    const char *log;
-    if (!dxl_wb_.itemWrite(motor_id, "Position_P_Gain", p, &log)) {
-      spdlog::error("Failed To set P Gain of motor {}: {}", motor_id, log);
-    }
-    if (!dxl_wb_.itemWrite(motor_id, "Position_I_Gain", i, &log)) {
-      spdlog::error("Failed To set I Gain of motor {}: {}", motor_id, log);
-    }
-    if (!dxl_wb_.itemWrite(motor_id, "Position_D_Gain", d, &log)) {
-      spdlog::error("Failed To set D Gain of motor {}: {}", motor_id, log);
-    }
-    spdlog::info(
-        "Successfully set PID = ({}, {}, {}) for motor {}", p, i, d, motor_id);
-  };
+    auto SetPIDSingleMotor = [this](uint8_t motor_id, int32_t p, int32_t i, int32_t d) -> void {
+        const char* log;
+        if (!dxl_wb_.itemWrite(motor_id, "Position_P_Gain", p, &log)) {
+            spdlog::error("Failed To set P Gain of motor {}: {}", motor_id, log);
+        }
+        if (!dxl_wb_.itemWrite(motor_id, "Position_I_Gain", i, &log)) {
+            spdlog::error("Failed To set I Gain of motor {}: {}", motor_id, log);
+        }
+        if (!dxl_wb_.itemWrite(motor_id, "Position_D_Gain", d, &log)) {
+            spdlog::error("Failed To set D Gain of motor {}: {}", motor_id, log);
+        }
+        spdlog::info("Successfully set PID = ({}, {}, {}) for motor {}", p, i, d, motor_id);
+    };
 
-  for (const PIDGain &gain_cfg : gain_cfgs) {
-    if (gain_cfg.name == "all") {
-      for (const MotorInfo &motor : profile_.motors) {
-        SetPIDSingleMotor(motor.id, gain_cfg.p, gain_cfg.i, gain_cfg.d);
-      }
-    } else if (const MotorInfo *motor = profile_.motor(gain_cfg.name)) {
-      SetPIDSingleMotor(motor->id, gain_cfg.p, gain_cfg.i, gain_cfg.d);
-    } else {
-      spdlog::error("Cannot set PID: motor '{}' not found", gain_cfg.name);
+    for (const PIDGain& gain_cfg : gain_cfgs) {
+        if (gain_cfg.name == "all") {
+            for (const MotorInfo& motor : profile_.motors) {
+                SetPIDSingleMotor(motor.id, gain_cfg.p, gain_cfg.i, gain_cfg.d);
+            }
+        }
+        else if (const MotorInfo* motor = profile_.motor(gain_cfg.name)) {
+            SetPIDSingleMotor(motor->id, gain_cfg.p, gain_cfg.i, gain_cfg.d);
+        }
+        else {
+            spdlog::error("Cannot set PID: motor '{}' not found", gain_cfg.name);
+        }
     }
-  }
 }
 
 bool WxArmorDriver::SafetyViolationTriggered() {
-  return safety_violation_.load();
+    return safety_violation_.load();
 }
 
-void WxArmorDriver::TriggerSafetyViolationMode() { safety_violation_ = true; }
+void WxArmorDriver::TriggerSafetyViolationMode() {
+    safety_violation_ = true;
+}
 
-void WxArmorDriver::ResetSafetyViolationMode() { safety_violation_ = false; }
+void WxArmorDriver::ResetSafetyViolationMode() {
+    safety_violation_ = false;
+}
 
-ControlItem WxArmorDriver::AddItemToRead(const std::string &name) {
-  // Here we assume that the data allocation on all the motors are
-  // identical. Therefore, we can just read the address of the motor ID and
-  // call it a day.
-  const ControlItem *address =
-      dxl_wb_.getItemInfo(profile_.joint_ids.front(), name.c_str());
+ControlItem WxArmorDriver::AddItemToRead(const std::string& name) {
+    // Here we assume that the data allocation on all the motors are
+    // identical. Therefore, we can just read the address of the motor ID and
+    // call it a day.
+    const ControlItem* address = dxl_wb_.getItemInfo(profile_.joint_ids.front(), name.c_str());
 
-  if (address == nullptr) {
-    spdlog::critical("Cannot find onboard item '{}' to read.", name);
-    std::abort();
-  } else {
-    spdlog::info("Register '{}' reader at (address = {}, length = {})",
-                 name,
-                 address->address,
-                 address->data_length);
-  }
+    if (address == nullptr) {
+        spdlog::critical("Cannot find onboard item '{}' to read.", name);
+        std::abort();
+    }
+    else {
+        spdlog::info("Register '{}' reader at (address = {}, length = {})", name, address->address,
+                     address->data_length);
+    }
 
-  read_start_ = std::min(read_start_, address->address);
-  read_end_ =
-      std::max(read_end_,
-               static_cast<uint16_t>(address->address + address->data_length));
+    read_start_ = std::min(read_start_, address->address);
+    read_end_ = std::max(read_end_, static_cast<uint16_t>(address->address + address->data_length));
 
-  return *address;
+    return *address;
 }
 
 void WxArmorDriver::InitReadHandler() {
-  read_position_address_ = AddItemToRead("Present_Position");
-  read_velocity_address_ = AddItemToRead("Present_Velocity");
-  read_current_address_ = AddItemToRead("Present_Current");
-  read_error_address_ = AddItemToRead("Hardware_Error_Status");
+    read_position_address_ = AddItemToRead("Present_Position");
+    read_velocity_address_ = AddItemToRead("Present_Velocity");
+    read_current_address_ = AddItemToRead("Present_Current");
+    read_error_address_ = AddItemToRead("Hardware_Error_Status");
 
-  read_handler_index_ = dxl_wb_.getTheNumberOfSyncReadHandler();
-  if (!dxl_wb_.addSyncReadHandler(read_start_, read_end_ - read_start_)) {
-    spdlog::critical("Failed to add sync read handler.");
-    std::abort();
-  } else {
-    spdlog::info("Registered sync read handler (address = {}, length = {})",
-                 read_start_,
-                 read_end_ - read_start_);
-  }
+    read_handler_index_ = dxl_wb_.getTheNumberOfSyncReadHandler();
+    if (!dxl_wb_.addSyncReadHandler(read_start_, read_end_ - read_start_)) {
+        spdlog::critical("Failed to add sync read handler.");
+        std::abort();
+    }
+    else {
+        spdlog::info("Registered sync read handler (address = {}, length = {})", read_start_,
+                     read_end_ - read_start_);
+    }
 }
 
 void WxArmorDriver::InitWriteHandler() {
-  static constexpr char GOAL_POSITION[] = "Goal_Position";
-  static constexpr char PROFILE_ACC[] = "Profile_Acceleration";
-  static constexpr char PROFILE_VEL[] = "Profile_Velocity";
+    static constexpr char GOAL_POSITION[] = "Goal_Position";
+    static constexpr char PROFILE_ACC[] = "Profile_Acceleration";
+    static constexpr char PROFILE_VEL[] = "Profile_Velocity";
 
-  OpMode op_mode = profile_.motors.front().op_mode;
-  if (op_mode != OpMode::POSITION &&
-      op_mode != OpMode::CURRENT_BASED_POSITION) {
-    spdlog::critical(
-        "WxArmorDriver only support Operation Mode 'POSITION' and "
-        "'CURRENT_BASED_POSITION'.");
-    std::abort();
-  }
+    OpMode op_mode = profile_.motors.front().op_mode;
+    if (op_mode != OpMode::POSITION && op_mode != OpMode::CURRENT_BASED_POSITION) {
+        spdlog::critical("WxArmorDriver only support Operation Mode 'POSITION' and "
+                         "'CURRENT_BASED_POSITION'.");
+        std::abort();
+    }
 
-  // Add the write handler that writes only the goal position
-  const ControlItem *goal_position_address =
-      dxl_wb_.getItemInfo(profile_.joint_ids.front(), GOAL_POSITION);
-  if (goal_position_address == nullptr) {
-    spdlog::critical("Cannot find onboard item '{}' to write.", GOAL_POSITION);
-    std::abort();
-  }
+    // Add the write handler that writes only the goal position
+    const ControlItem* goal_position_address =
+        dxl_wb_.getItemInfo(profile_.joint_ids.front(), GOAL_POSITION);
+    if (goal_position_address == nullptr) {
+        spdlog::critical("Cannot find onboard item '{}' to write.", GOAL_POSITION);
+        std::abort();
+    }
 
-  write_position_address_ = *goal_position_address;
+    write_position_address_ = *goal_position_address;
 
-  write_position_handler_index_ = dxl_wb_.getTheNumberOfSyncWriteHandler();
-  if (!dxl_wb_.addSyncWriteHandler(write_position_address_.address,
-                                   write_position_address_.data_length)) {
-    spdlog::critical("Failed to add sync write handler for {}", GOAL_POSITION);
-    std::abort();
-  } else {
-    spdlog::info(
-        "Registered sync write handler for {} (address = {}, length = {})",
-        GOAL_POSITION,
-        write_position_address_.address,
-        write_position_address_.data_length);
-  }
+    write_position_handler_index_ = dxl_wb_.getTheNumberOfSyncWriteHandler();
+    if (!dxl_wb_.addSyncWriteHandler(write_position_address_.address,
+                                     write_position_address_.data_length)) {
+        spdlog::critical("Failed to add sync write handler for {}", GOAL_POSITION);
+        std::abort();
+    }
+    else {
+        spdlog::info("Registered sync write handler for {} (address = {}, length = {})",
+                     GOAL_POSITION, write_position_address_.address,
+                     write_position_address_.data_length);
+    }
 
-  // Add the write handler that writes the goal position, as well as
-  // the velocity and acceleration profile.
-  const ControlItem *profile_vel_address =
-      dxl_wb_.getItemInfo(profile_.joint_ids.front(), PROFILE_VEL);
-  const ControlItem *profile_acc_address =
-      dxl_wb_.getItemInfo(profile_.joint_ids.front(), PROFILE_ACC);
-  if (profile_acc_address->address + profile_acc_address->data_length !=
-      profile_vel_address->address) {
-    spdlog::critical(
-        "The register address of profile acceleration is not "
-        "next to that of profile velocity");
-    std::abort();
-  }
-  if (profile_vel_address->address + profile_vel_address->data_length !=
-      goal_position_address->address) {
-    spdlog::critical(
-        "The register address of profile velocity is not "
-        "next to that of goal position");
-    std::abort();
-  }
+    // Add the write handler that writes the goal position, as well as
+    // the velocity and acceleration profile.
+    const ControlItem* profile_vel_address =
+        dxl_wb_.getItemInfo(profile_.joint_ids.front(), PROFILE_VEL);
+    const ControlItem* profile_acc_address =
+        dxl_wb_.getItemInfo(profile_.joint_ids.front(), PROFILE_ACC);
+    if (profile_acc_address->address + profile_acc_address->data_length !=
+        profile_vel_address->address) {
+        spdlog::critical("The register address of profile acceleration is not "
+                         "next to that of profile velocity");
+        std::abort();
+    }
+    if (profile_vel_address->address + profile_vel_address->data_length !=
+        goal_position_address->address) {
+        spdlog::critical("The register address of profile velocity is not "
+                         "next to that of goal position");
+        std::abort();
+    }
 
-  write_position_and_profile_handler_index_ =
-      dxl_wb_.getTheNumberOfSyncWriteHandler();
+    write_position_and_profile_handler_index_ = dxl_wb_.getTheNumberOfSyncWriteHandler();
 
-  uint16_t start = profile_acc_address->address;
-  uint16_t length = profile_acc_address->data_length +
-                    profile_vel_address->data_length +
-                    goal_position_address->data_length;
+    uint16_t start = profile_acc_address->address;
+    uint16_t length = profile_acc_address->data_length + profile_vel_address->data_length +
+                      goal_position_address->data_length;
 
-  if (!dxl_wb_.addSyncWriteHandler(start, length)) {
-    spdlog::critical("Failed to add sync write handler for {} + {} + {}",
-                     PROFILE_VEL,
-                     PROFILE_ACC,
-                     GOAL_POSITION);
-    std::abort();
-  } else {
-    spdlog::info(
-        "Registered sync write handler for {} + {} + {} (address = {}, "
-        "length "
-        "= {})",
-        PROFILE_VEL,
-        PROFILE_ACC,
-        GOAL_POSITION,
-        start,
-        length);
-  }
+    if (!dxl_wb_.addSyncWriteHandler(start, length)) {
+        spdlog::critical("Failed to add sync write handler for {} + {} + {}", PROFILE_VEL,
+                         PROFILE_ACC, GOAL_POSITION);
+        std::abort();
+    }
+    else {
+        spdlog::info("Registered sync write handler for {} + {} + {} (address = {}, "
+                     "length "
+                     "= {})",
+                     PROFILE_VEL, PROFILE_ACC, GOAL_POSITION, start, length);
+    }
 }
 
 }  // namespace horizon::wx_armor

--- a/wx_armor/wx_armor/wx_armor_driver.h
+++ b/wx_armor/wx_armor/wx_armor_driver.h
@@ -48,7 +48,8 @@
 #include "wx_armor/robot_profile.h"
 #include "yaml-cpp/yaml.h"
 
-namespace horizon::wx_armor {
+namespace horizon::wx_armor
+{
 
 /**
  * @struct SensorData
@@ -59,26 +60,27 @@ namespace horizon::wx_armor {
  * includes a timestamp to indicate the time at which these readings were taken
  * or requested *
  */
-struct SensorData {
-  // ┌──────────────────┐
-  // │ Per Joint        │
-  // └──────────────────┘
+struct SensorData
+{
+    // ┌──────────────────┐
+    // │ Per Joint        │
+    // └──────────────────┘
 
-  std::vector<float> pos{};  // joint position
-  std::vector<float> vel{};  // joint velocity
-  std::vector<float> crt{};  // motor electric current of this joint
-  std::vector<uint32_t> err{};  // per joint error codes
+    std::vector<float> pos{};     // joint position
+    std::vector<float> vel{};     // joint velocity
+    std::vector<float> crt{};     // motor electric current of this joint
+    std::vector<uint32_t> err{};  // per joint error codes
 
-  // ┌──────────────────┐
-  // │ Metadata         │
-  // └──────────────────┘
+    // ┌──────────────────┐
+    // │ Metadata         │
+    // └──────────────────┘
 
-  // The timestamp at which the sensor data is requested, which is approximately
-  // when the measurement is taken. Since it is an approximation with around 2ms
-  // error, it is only expected to be used as a reference.
-  int64_t timestamp = 0;
+    // The timestamp at which the sensor data is requested, which is
+    // approximately when the measurement is taken. Since it is an approximation
+    // with around 2ms error, it is only expected to be used as a reference.
+    int64_t timestamp = 0;
 
-  NLOHMANN_DEFINE_TYPE_INTRUSIVE(SensorData, pos, vel, crt, err, timestamp);
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE(SensorData, pos, vel, crt, err, timestamp);
 };
 
 /**
@@ -90,17 +92,18 @@ struct SensorData {
  * motor names or applying the same gains to all motors by using "all" as the
  * motor name.
  */
-struct PIDGain {
-  //  The name of the motor. Use "all" to apply to all motors.
-  std::string name = "";
-  // The proportional gain for the PID controller.
-  int32_t p = 0;
-  // The integral gain for the PID controller.
-  int32_t i = 0;
-  // The derivative gain for the PID controller.
-  int32_t d = 0;
+struct PIDGain
+{
+    //  The name of the motor. Use "all" to apply to all motors.
+    std::string name = "";
+    // The proportional gain for the PID controller.
+    int32_t p = 0;
+    // The integral gain for the PID controller.
+    int32_t i = 0;
+    // The derivative gain for the PID controller.
+    int32_t d = 0;
 
-  NLOHMANN_DEFINE_TYPE_INTRUSIVE(PIDGain, name, p, i, d);
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE(PIDGain, name, p, i, d);
 };
 
 /**
@@ -113,10 +116,10 @@ struct PIDGain {
  * sensor data, setting joint positions, and enabling/disabling motor torque.
  * The driver communicates with the motors through a specified USB port and
  * follows configurations defined in a motor configuration file.
- * 
- * @note The WxArmorDriver should never be used by applications directly, as it does not
- * provide any safety protections.
- * Instead, it should only be invoked through the WxArmorWebController class as of now.
+ *
+ * @note The WxArmorDriver should never be used by applications directly, as it
+ * does not provide any safety protections. Instead, it should only be invoked
+ * through the WxArmorWebController class as of now.
  *
  * Usage:
  * @code
@@ -130,210 +133,211 @@ struct PIDGain {
  * @note This driver is specific to robots with Dynamixel motors and requires
  * the Dynamixel SDK for low-level communications.
  */
-class WxArmorDriver {
- public:
-  /**
-   * @brief Constructs a WxArmorDriver object.
-   * @param usb_port The USB port through which the robot is connected.
-   * @param motor_config_path Filesystem path to the motor configuration file.
-   * @param flash_eeprom Flag to indicate whether to flash the EEPROM on
-   * construction.
-   */
-  WxArmorDriver(const std::string &usb_port,
-                std::filesystem::path motor_config_path,
-                bool flash_eeprom = false);
+class WxArmorDriver
+{
+  public:
+    /**
+     * @brief Constructs a WxArmorDriver object.
+     * @param usb_port The USB port through which the robot is connected.
+     * @param motor_config_path Filesystem path to the motor configuration file.
+     * @param flash_eeprom Flag to indicate whether to flash the EEPROM on
+     * construction.
+     */
+    WxArmorDriver(const std::string& usb_port, std::filesystem::path motor_config_path,
+                  bool flash_eeprom = false);
 
-  ~WxArmorDriver();
+    ~WxArmorDriver();
 
-  /**
-   * @brief Read the latest sensor data from the robot and returns it.
-   * @details This method is blocking and typically takes around 2ms to
-   * complete.
-   *
-   * @return The read sensor data if the read is successful. Or std::nullopt if
-   *         the read fails.
-   */
-  std::optional<SensorData> Read();
+    /**
+     * @brief Read the latest sensor data from the robot and returns it.
+     * @details This method is blocking and typically takes around 2ms to
+     * complete.
+     *
+     * @return The read sensor data if the read is successful. Or std::nullopt
+     * if the read fails.
+     */
+    std::optional<SensorData> Read();
 
-  /**
-   * @brief Check that all motors are health.
-   *
-   * @return Returns true if all motors are reachable and false otherwise.
-   */
-  bool MotorHealthCheck();
+    /**
+     * @brief Check that all motors are health.
+     *
+     * @return Returns true if all motors are reachable and false otherwise.
+     */
+    bool MotorHealthCheck();
 
-  /**
-   * @brief Reads the safety velocity limits from RobotProfile and returns it.
-   *
-   * @return An array containing the safety velocity limits for each motor
-   *         [rad/s].
-   */
-  std::vector<float> GetSafetyVelocityLimits();
+    /**
+     * @brief Reads the safety velocity limits from RobotProfile and returns it.
+     *
+     * @return An array containing the safety velocity limits for each motor
+     *         [rad/s].
+     */
+    std::vector<float> GetSafetyVelocityLimits();
 
-  /**
-   * @brief Reads the safety current limits from RobotProfile and returns it.
-   *
-   * @return An array containing the safety current limits for each motor [mA].
-   */
-  std::vector<float> GetSafetyCurrentLimits();
+    /**
+     * @brief Reads the safety current limits from RobotProfile and returns it.
+     *
+     * @return An array containing the safety current limits for each motor
+     * [mA].
+     */
+    std::vector<float> GetSafetyCurrentLimits();
 
-  /**
-   * @brief Sets the position of the robot's joints, with a desired moving and
-   * acceleration time.
-   * @details If acc_time is zero, constant velocity is used.
-   * @param position A vector of floats representing the desired joint
-   * positions.
-   * @param moving_time A float in seconds
-   * @param acc_time A float in seconds
-   */
-  void SetPosition(const std::vector<float> &position,
-                   float moving_time,
-                   float acc_time = 0.0);
+    /**
+     * @brief Sets the position of the robot's joints, with a desired moving and
+     * acceleration time.
+     * @details If acc_time is zero, constant velocity is used.
+     * @param position A vector of floats representing the desired joint
+     * positions.
+     * @param moving_time A float in seconds
+     * @param acc_time A float in seconds
+     */
+    void SetPosition(const std::vector<float>& position, float moving_time, float acc_time = 0.0);
 
-  /**
-   * @brief Activates the torque in the robot's motors.
-   *
-   * @details When this method is called, the motors of the robot's joints start
-   * generating torque based on the provided commands. This enables the robot to
-   * maintain or move to the specified positions. It's essential to call this
-   * method before attempting to move the robot, as it 'energizes' the joints,
-   * preparing them for active motion. TorqueOn() will be called automatically
-   * upon construction of this driver class.
-   *
-   * @note when the robot is torque back on, it will not remember the previous
-   * position command and goto there. It will remain the position when it is
-   * torqued on.
-   */
-  void TorqueOn();
+    /**
+     * @brief Activates the torque in the robot's motors.
+     *
+     * @details When this method is called, the motors of the robot's joints
+     * start generating torque based on the provided commands. This enables the
+     * robot to maintain or move to the specified positions. It's essential to
+     * call this method before attempting to move the robot, as it 'energizes'
+     * the joints, preparing them for active motion. TorqueOn() will be called
+     * automatically upon construction of this driver class.
+     *
+     * @note when the robot is torque back on, it will not remember the previous
+     * position command and goto there. It will remain the position when it is
+     * torqued on.
+     */
+    void TorqueOn();
 
-  /**
-   * @brief Deactivates the torque in the robot's motors.
-   *
-   * @details Calling this method will cause the motors of the robot's joints to
-   * stop producing torque. As a result, the robot becomes 'soft' and will not
-   * resist external forces. This state is useful for safely handling the robot,
-   * performing maintenance, or when the robot is in a powered-down or idle
-   * state.
-   */
-  void TorqueOff();
+    /**
+     * @brief Deactivates the torque in the robot's motors.
+     *
+     * @details Calling this method will cause the motors of the robot's joints
+     * to stop producing torque. As a result, the robot becomes 'soft' and will
+     * not resist external forces. This state is useful for safely handling the
+     * robot, performing maintenance, or when the robot is in a powered-down or
+     * idle state.
+     */
+    void TorqueOff();
 
-  /**
-   * @brief Sets the PID gains for one or more motors based on the provided
-   * configurations.
-   *
-   * This function iterates through a list of PIDGain configurations,
-   * applying each configuration to the specified motor or all motors.
-   * If a motor's name does not match any in the profile or if "all"
-   * is specified but some motors cannot be configured, an error is
-   * logged. The function aims for flexible and efficient PID
-   * configuration across different motors in a robot using Dynamixel
-   * actuators.
-   *
-   * @param gain_cfgs A vector of PIDGain structures containing the gain
-   * configurations for the motors. Each structure specifies a motor name and
-   * the PID gains to apply. If the name is "all", the gains are applied to all
-   * motors.
-   *
-   * Usage Examples:
-   *     - To set PID gains for a specific motor: [{"name": "waist", "p":
-   *       800, "i": 0, "d": 3}]
-   *     - To set PID gains for all motors, with a different configuration for
-   *       one motor: [{"name": "all", "p": 800, "i": 0, "d": 3}, {"name":
-   *       "wrist", "p": 400, "i": 0, "d": 0}]
-   */
-  void SetPID(const std::vector<PIDGain> &gain_cfgs);
+    /**
+     * @brief Sets the PID gains for one or more motors based on the provided
+     * configurations.
+     *
+     * This function iterates through a list of PIDGain configurations,
+     * applying each configuration to the specified motor or all motors.
+     * If a motor's name does not match any in the profile or if "all"
+     * is specified but some motors cannot be configured, an error is
+     * logged. The function aims for flexible and efficient PID
+     * configuration across different motors in a robot using Dynamixel
+     * actuators.
+     *
+     * @param gain_cfgs A vector of PIDGain structures containing the gain
+     * configurations for the motors. Each structure specifies a motor name and
+     * the PID gains to apply. If the name is "all", the gains are applied to
+     * all motors.
+     *
+     * Usage Examples:
+     *     - To set PID gains for a specific motor: [{"name": "waist", "p":
+     *       800, "i": 0, "d": 3}]
+     *     - To set PID gains for all motors, with a different configuration for
+     *       one motor: [{"name": "all", "p": 800, "i": 0, "d": 3}, {"name":
+     *       "wrist", "p": 400, "i": 0, "d": 0}]
+     */
+    void SetPID(const std::vector<PIDGain>& gain_cfgs);
 
-  /**
-   * @brief Returns the current safety violation mode status.
-   *
-   * @return A bool describing whether a safety violation is currently
-   * triggered and not reset.
-   */
-  bool SafetyViolationTriggered();
+    /**
+     * @brief Returns the current safety violation mode status.
+     *
+     * @return A bool describing whether a safety violation is currently
+     * triggered and not reset.
+     */
+    bool SafetyViolationTriggered();
 
-  /**
-   * @brief Sets off safety violation mode.
-   *
-   * @details For functionality to return to normal, ResetSafetyViolation()
-   * must be called.
-   */
-  void TriggerSafetyViolationMode();
+    /**
+     * @brief Sets off safety violation mode.
+     *
+     * @details For functionality to return to normal, ResetSafetyViolation()
+     * must be called.
+     */
+    void TriggerSafetyViolationMode();
 
-  /**
-   * @brief Resets the safety violation status back to false.
-   *
-   * @note Currently, this gets called only when a new client connection
-   * is made after all previous connections are closed.
-   */
-  void ResetSafetyViolationMode();
+    /**
+     * @brief Resets the safety violation status back to false.
+     *
+     * @note Currently, this gets called only when a new client connection
+     * is made after all previous connections are closed.
+     */
+    void ResetSafetyViolationMode();
 
-  /**
-   * @brief Returns the profile of the robot.
-   */
-  const RobotProfile &Profile() const { return profile_; }
+    /**
+     * @brief Returns the profile of the robot.
+     */
+    const RobotProfile& Profile() const {
+        return profile_;
+    }
 
- private:
-  ControlItem AddItemToRead(const std::string &name);
+  private:
+    ControlItem AddItemToRead(const std::string& name);
 
-  void InitReadHandler();
+    void InitReadHandler();
 
-  void InitWriteHandler();
+    void InitWriteHandler();
 
-  // ┌──────────────────┐
-  // │ The motor handle │
-  // └──────────────────┘
+    // ┌──────────────────┐
+    // │ The motor handle │
+    // └──────────────────┘
 
-  DynamixelWorkbench dxl_wb_;
+    DynamixelWorkbench dxl_wb_;
 
-  // ┌───────────────┐
-  // │ Info (static) │
-  // └───────────────┘
+    // ┌───────────────┐
+    // │ Info (static) │
+    // └───────────────┘
 
-  RobotProfile profile_;
+    RobotProfile profile_;
 
-  // ┌──────────────────┐
-  // │ Read             │
-  // └──────────────────┘
+    // ┌──────────────────┐
+    // │ Read             │
+    // └──────────────────┘
 
-  std::mutex io_mutex_;  // protects IO from dxl_wb_.
+    std::mutex io_mutex_;  // protects IO from dxl_wb_.
 
-  uint8_t read_handler_index_ = 0;
+    uint8_t read_handler_index_ = 0;
 
-  // A ControlItem is Dynamixel SDK's terminology of describing the address
-  // where the corresponding information is stored on each motor. Each address
-  // (i.e. ControlItem) consists of a starting address and a length, where the
-  // unit is of Bytes.
-  ControlItem read_position_address_;
-  ControlItem read_velocity_address_;
-  ControlItem read_current_address_;
-  ControlItem read_error_address_;
+    // A ControlItem is Dynamixel SDK's terminology of describing the address
+    // where the corresponding information is stored on each motor. Each address
+    // (i.e. ControlItem) consists of a starting address and a length, where the
+    // unit is of Bytes.
+    ControlItem read_position_address_;
+    ControlItem read_velocity_address_;
+    ControlItem read_current_address_;
+    ControlItem read_error_address_;
 
-  // Union address interval of the above 3. Note that `read_end_` address is
-  // not inclusive (open interval). We need this so that we can issue command
-  // to the motors to read such data resides within the address interval.
-  uint16_t read_start_ = std::numeric_limits<uint16_t>::max();
-  uint16_t read_end_ = 0;
+    // Union address interval of the above 3. Note that `read_end_` address is
+    // not inclusive (open interval). We need this so that we can issue command
+    // to the motors to read such data resides within the address interval.
+    uint16_t read_start_ = std::numeric_limits<uint16_t>::max();
+    uint16_t read_end_ = 0;
 
-  // ┌──────────────────┐
-  // │ Write            │
-  // └──────────────────┘
+    // ┌──────────────────┐
+    // │ Write            │
+    // └──────────────────┘
 
-  // Unlike write, in the future we may have write handler for each of the
-  // operation mode (e.g. position control, velocity control, pwm control).
-  // Therefore we will need to store handler index for each of them.
-  uint8_t write_position_handler_index_;
+    // Unlike write, in the future we may have write handler for each of the
+    // operation mode (e.g. position control, velocity control, pwm control).
+    // Therefore we will need to store handler index for each of them.
+    uint8_t write_position_handler_index_;
 
-  // Similar to how we read, we also write to identical addresses on each
-  // motor.
-  ControlItem write_position_address_;
+    // Similar to how we read, we also write to identical addresses on each
+    // motor.
+    ControlItem write_position_address_;
 
-  // Index to the write handler that writes both the position and velocity and
-  // acceleration profile, and the corresponding register addresses.
-  uint8_t write_position_and_profile_handler_index_;
+    // Index to the write handler that writes both the position and velocity and
+    // acceleration profile, and the corresponding register addresses.
+    uint8_t write_position_and_profile_handler_index_;
 
-  // Flag that gets triggered when safety violations such as
-  // velocity limits are violated.
-  std::atomic_bool safety_violation_{false};
+    // Flag that gets triggered when safety violations such as
+    // velocity limits are violated.
+    std::atomic_bool safety_violation_{false};
 };
 
 }  // namespace horizon::wx_armor

--- a/wx_armor/wx_armor/wx_armor_ws.cc
+++ b/wx_armor/wx_armor/wx_armor_ws.cc
@@ -13,346 +13,345 @@ using drogon::HttpRequestPtr;
 using drogon::WebSocketConnectionPtr;
 using drogon::WebSocketMessageType;
 
-namespace horizon::wx_armor {
+namespace horizon::wx_armor
+{
 
-WxArmorDriver *Driver() {
-  static std::unique_ptr<WxArmorDriver> driver = []() {
-    std::string usb_port =
-        GetEnv<std::string>("WX_ARMOR_USB_PORT", "/dev/ttyDXL");
-    std::filesystem::path motor_config = GetEnv<std::filesystem::path>(
-        "WX_ARMOR_MOTOR_CONFIG",
-        std::filesystem::path(__FILE__)
-                .parent_path()
-                .parent_path()
-                .parent_path() /
-            "configs" / "wx250s_motor_config.yaml");
-    int flash_eeprom = true;
-    return std::make_unique<WxArmorDriver>(
-        usb_port, motor_config, static_cast<bool>(flash_eeprom));
-  }();
-  return driver.get();
+WxArmorDriver* Driver() {
+    static std::unique_ptr<WxArmorDriver> driver = []() {
+        std::string usb_port = GetEnv<std::string>("WX_ARMOR_USB_PORT", "/dev/ttyDXL");
+        std::filesystem::path motor_config = GetEnv<std::filesystem::path>(
+            "WX_ARMOR_MOTOR_CONFIG",
+            std::filesystem::path(__FILE__).parent_path().parent_path().parent_path() / "configs" /
+                "wx250s_motor_config.yaml");
+        int flash_eeprom = true;
+        return std::make_unique<WxArmorDriver>(usb_port, motor_config,
+                                               static_cast<bool>(flash_eeprom));
+    }();
+    return driver.get();
 }
 
-void WxArmorWebController::handleNewMessage(const WebSocketConnectionPtr &conn,
-                                            std::string &&message,
-                                            const WebSocketMessageType &type) {
-  std::string_view payload{};
+void WxArmorWebController::handleNewMessage(const WebSocketConnectionPtr& conn,
+                                            std::string&& message,
+                                            const WebSocketMessageType& type) {
+    std::string_view payload{};
 
-  // Valid message should be in the format of "<COMMAND> <PAYLOAD>". This helper
-  // function try to match the message with predefined command, and if there is
-  // a match, put the payload into `payload`.
-  auto Match = [&message, &payload](const char *command) -> bool {
-    size_t command_length = strlen(command);
-    if (std::strncmp(message.data(), command, command_length) == 0) {
-      payload = std::string_view(message.data() + command_length + 1,
-                                 message.size() - command_length - 1);
-      return true;
+    // Valid message should be in the format of "<COMMAND> <PAYLOAD>". This
+    // helper function try to match the message with predefined command, and if
+    // there is a match, put the payload into `payload`.
+    auto Match = [&message, &payload](const char* command) -> bool {
+        size_t command_length = strlen(command);
+        if (std::strncmp(message.data(), command, command_length) == 0) {
+            payload = std::string_view(message.data() + command_length + 1,
+                                       message.size() - command_length - 1);
+            return true;
+        }
+        return false;
+    };
+
+    if (type != WebSocketMessageType::Text) {
+        // This happens during keepalive or closing connection, ignored
     }
-    return false;
-  };
-
-  if (type != WebSocketMessageType::Text) {
-    // This happens during keepalive or closing connection, ignored
-  } else if (Match("SETPID") && !Driver()->Read().has_value()) {
-    // Allow client to reset error status via SETPID only if driver can read motors
-    spdlog::error("SETPID ignored.  Cannot read");
-  } else if (Driver()->SafetyViolationTriggered() && !Match("SETPID") &&
-             !Match("MOVETO")) {
-    // If safety violation is triggered, ignore all commands except SETPID
-    // which resets error status, and MOVETO which allows the client to set
-    // the jointpos command to the current position to avoid jumps after SETPID.
-    spdlog::error(
-      "Call from message handler ignored. Safety violation was encountered.");
-  } else if (Match("SETPOS")) {
-    // Update the states for bookkeeping purpose.
-    ClientState &state = conn->getContextRef<ClientState>();
-    state.engaging = true;
-    state.latest_healthy_time = std::chrono::system_clock::now();
-
-    // Relay the command to the driver.
-    nlohmann::json json = nlohmann::json::parse(payload);
-    std::vector<float> position(json.size());
-    for (size_t i = 0; i < json.size(); ++i) {
-      position[i] = json.at(i).get<float>();
+    else if (Match("SETPID") && !Driver()->Read().has_value()) {
+        // Allow client to reset error status via SETPID only if driver can read
+        // motors
+        spdlog::error("SETPID ignored.  Cannot read");
     }
-    CheckAndSetPosition(position, 0.0);
-  } else if (Match("MOVETO")) {
-    // Update the states for bookkeeping purpose.
-    ClientState &state = conn->getContextRef<ClientState>();
-    state.engaging = true;
-    state.latest_healthy_time = std::chrono::system_clock::now();
-
-    // Relay the command to the driver. Note that the last numbers
-    // in the list is the moving time, in seconds.
-    nlohmann::json json = nlohmann::json::parse(payload);
-    std::vector<float> position(json.size() - 1);
-    for (size_t i = 0; i < json.size() - 1; ++i) {
-      position[i] = json.at(i).get<float>();
+    else if (Driver()->SafetyViolationTriggered() && !Match("SETPID") && !Match("MOVETO")) {
+        // If safety violation is triggered, ignore all commands except SETPID
+        // which resets error status, and MOVETO which allows the client to set
+        // the jointpos command to the current position to avoid jumps after
+        // SETPID.
+        spdlog::error("Call from message handler ignored. Safety violation was "
+                      "encountered.");
     }
-    float moving_time = json.at(json.size() - 1).get<float>();
-    CheckAndSetPosition(position, moving_time);
-  } else if (Match("TORQUE ON")) {
-    Driver()->TorqueOn();
-  } else if (Match("TORQUE OFF")) {
-    Driver()->TorqueOff();
-  } else if (Match("SETPID")) {
-    std::vector<PIDGain> gain_cfgs = nlohmann::json::parse(payload);
-    Driver()->SetPID(gain_cfgs);
-    guardian_thread_.ResetErrorCodes();
-  }
+    else if (Match("SETPOS")) {
+        // Update the states for bookkeeping purpose.
+        ClientState& state = conn->getContextRef<ClientState>();
+        state.engaging = true;
+        state.latest_healthy_time = std::chrono::system_clock::now();
+
+        // Relay the command to the driver.
+        nlohmann::json json = nlohmann::json::parse(payload);
+        std::vector<float> position(json.size());
+        for (size_t i = 0; i < json.size(); ++i) {
+            position[i] = json.at(i).get<float>();
+        }
+        CheckAndSetPosition(position, 0.0);
+    }
+    else if (Match("MOVETO")) {
+        // Update the states for bookkeeping purpose.
+        ClientState& state = conn->getContextRef<ClientState>();
+        state.engaging = true;
+        state.latest_healthy_time = std::chrono::system_clock::now();
+
+        // Relay the command to the driver. Note that the last numbers
+        // in the list is the moving time, in seconds.
+        nlohmann::json json = nlohmann::json::parse(payload);
+        std::vector<float> position(json.size() - 1);
+        for (size_t i = 0; i < json.size() - 1; ++i) {
+            position[i] = json.at(i).get<float>();
+        }
+        float moving_time = json.at(json.size() - 1).get<float>();
+        CheckAndSetPosition(position, moving_time);
+    }
+    else if (Match("TORQUE ON")) {
+        Driver()->TorqueOn();
+    }
+    else if (Match("TORQUE OFF")) {
+        Driver()->TorqueOff();
+    }
+    else if (Match("SETPID")) {
+        std::vector<PIDGain> gain_cfgs = nlohmann::json::parse(payload);
+        Driver()->SetPID(gain_cfgs);
+        guardian_thread_.ResetErrorCodes();
+    }
 }
 
-void WxArmorWebController::handleConnectionClosed(
-    const WebSocketConnectionPtr &conn) {
-  guardian_thread_.Unsubscribe(conn);
-  spdlog::info("A connection is closed.");
+void WxArmorWebController::handleConnectionClosed(const WebSocketConnectionPtr& conn) {
+    guardian_thread_.Unsubscribe(conn);
+    spdlog::info("A connection is closed.");
 }
 
-void WxArmorWebController::handleNewConnection(
-    const HttpRequestPtr &req, const WebSocketConnectionPtr &conn) {
-  conn->setContext(std::make_shared<ClientState>());
-  guardian_thread_.Subscribe(conn);
-  spdlog::info("A new connection is established.");
-  conn->send("ok");
+void WxArmorWebController::handleNewConnection(const HttpRequestPtr& req,
+                                               const WebSocketConnectionPtr& conn) {
+    conn->setContext(std::make_shared<ClientState>());
+    guardian_thread_.Subscribe(conn);
+    spdlog::info("A new connection is established.");
+    conn->send("ok");
 }
 
 static constexpr int MAX_TOLERABLE_CONSECUTIVE_NUM_READ_ERRORS = 6;
 
-void SlowDownToStop(const SensorData &curr_reading,
-                    float dt = 0.5,
-                    float deceleration_time = 1.5) {
-  std::vector<float> curr_pos = curr_reading.pos;
-  std::vector<float> curr_vel = curr_reading.vel;
-  std::vector<float> targets;
+void SlowDownToStop(const SensorData& curr_reading, float dt = 0.5, float deceleration_time = 1.5) {
+    std::vector<float> curr_pos = curr_reading.pos;
+    std::vector<float> curr_vel = curr_reading.vel;
+    std::vector<float> targets;
 
-  for (size_t i = 0; i < curr_pos.size(); i++) {
-    // Just some simple kinematic integration to minimize acceleration changes
-    float curr_target = curr_pos[i] + curr_vel[i] * dt;
-    targets.push_back(curr_target);
-  }
+    for (size_t i = 0; i < curr_pos.size(); i++) {
+        // Just some simple kinematic integration to minimize acceleration
+        // changes
+        float curr_target = curr_pos[i] + curr_vel[i] * dt;
+        targets.push_back(curr_target);
+    }
 
-  // Overwrite the current trajectory with our decelerating one.
-  Driver()->SetPosition(targets, deceleration_time, 0.49 * deceleration_time);
-  // SetPID to zero Kp, large Kd and zero Ki to drop to the ground from current pos.
-  Driver()->SetPID({{"all", 0, 0, 80000}});
+    // Overwrite the current trajectory with our decelerating one.
+    Driver()->SetPosition(targets, deceleration_time, 0.49 * deceleration_time);
+    // SetPID to zero Kp, large Kd and zero Ki to drop to the ground from
+    // current pos.
+    Driver()->SetPID({{"all", 0, 0, 80000}});
 }
 
-void WxArmorWebController::CheckAndSetPosition(const std::vector<float> &cmd,
-                                               float moving_time) {
-  const SensorData readings = guardian_thread_.GetCachedSensorData();
-  for (int i = 0; i + 1 < cmd.size(); i++) {
-    // Ignore last position for the grippers
-    float reading = readings.pos.at(i);
-    // 0.2 is a generous action delta for pid control
-    float thd = 0.2;
-    if (moving_time > 0.1)
-      thd = 2.5 * moving_time;
-    if (!Driver()->SafetyViolationTriggered() && fabs(reading - cmd[i]) > thd) {
-      spdlog::error(
-          "Joint {} command is out of range: {} -> {} > {}. Command ignored.",
-          i,
-          reading,
-          cmd[i],
-          thd);
-      Driver()->TriggerSafetyViolationMode();
-      guardian_thread_.SetErrorCode(i, GuardianThread::kErrorCommandDeltaTooLarge);
-      SlowDownToStop(readings);
-      // guardian_thread_.KillConnections();
-      return;
+void WxArmorWebController::CheckAndSetPosition(const std::vector<float>& cmd, float moving_time) {
+    const SensorData readings = guardian_thread_.GetCachedSensorData();
+    for (int i = 0; i + 1 < cmd.size(); i++) {
+        // Ignore last position for the grippers
+        float reading = readings.pos.at(i);
+        // 0.2 is a generous action delta for pid control
+        float thd = 0.2;
+        if (moving_time > 0.1)
+            thd = 2.5 * moving_time;
+        if (!Driver()->SafetyViolationTriggered() && fabs(reading - cmd[i]) > thd) {
+            spdlog::error("Joint {} command is out of range: {} -> {} > {}. Command "
+                          "ignored.",
+                          i, reading, cmd[i], thd);
+            Driver()->TriggerSafetyViolationMode();
+            guardian_thread_.SetErrorCode(i, GuardianThread::kErrorCommandDeltaTooLarge);
+            SlowDownToStop(readings);
+            // guardian_thread_.KillConnections();
+            return;
+        }
     }
-  }
-  Driver()->SetPosition(cmd, moving_time);
-  if (!Driver()->SafetyViolationTriggered() && !Driver()->MotorHealthCheck()) {
-    Driver()->TriggerSafetyViolationMode();
-    guardian_thread_.SetErrorCode(0, GuardianThread::kErrorMotorNotReachable);
-    SlowDownToStop(readings);
-    return;
-  }
+    Driver()->SetPosition(cmd, moving_time);
+    if (!Driver()->SafetyViolationTriggered() && !Driver()->MotorHealthCheck()) {
+        Driver()->TriggerSafetyViolationMode();
+        guardian_thread_.SetErrorCode(0, GuardianThread::kErrorMotorNotReachable);
+        SlowDownToStop(readings);
+        return;
+    }
 }
 
 WxArmorWebController::GuardianThread::GuardianThread() {
-  thread_ = std::jthread([this]() {
-    std::vector<float> safety_velocity_limits =
-        Driver()->GetSafetyVelocityLimits();
-    std::vector<float> safety_current_limits =
-        Driver()->GetSafetyCurrentLimits();
-    bool logged = false;
-    while (!shutdown_.load()) {
-      // Read the sensor data
-      std::optional<SensorData> sensor_data = Driver()->Read();
+    thread_ = std::jthread([this]() {
+        std::vector<float> safety_velocity_limits = Driver()->GetSafetyVelocityLimits();
+        std::vector<float> safety_current_limits = Driver()->GetSafetyCurrentLimits();
+        bool logged = false;
+        while (!shutdown_.load()) {
+            // Read the sensor data
+            std::optional<SensorData> sensor_data = Driver()->Read();
 
-      // Publish the sensor data
-      if (sensor_data.has_value() || Driver()->SafetyViolationTriggered()) {
-        if (!sensor_data.has_value()) {
-          // If we have an error, we still want to publish the error codes
-          static const uint8_t num_joints = Driver()->Profile().joint_ids.size();
-          sensor_data = SensorData{.pos = std::vector<float>(num_joints),
-                                   .vel = std::vector<float>(num_joints),
-                                   .crt = std::vector<float>(num_joints),
-                                   .err = error_codes_,
-                                   .timestamp = -1};
-        } else {
-          std::unique_lock<std::mutex> cache_lock{cache_mutex_};
-          // merge sensor_data's error codes with the existing ones with bitwise OR
-          error_codes_.resize(sensor_data.value().err.size());
-          for (size_t i = 0; i < sensor_data.value().err.size(); i++) {
-            // Do not call SetErrorCode() here, due to deadlocking of cache_mutex_
-            error_codes_[i] |= sensor_data.value().err[i];
-            if (!logged && sensor_data.value().err[i] != 0) {
-              spdlog::error(
-                  "Guardian thread detected hardware error for motor {}. Error "
-                  "code: {}",
-                  i,
-                  sensor_data.value().err[i]);
+            // Publish the sensor data
+            if (sensor_data.has_value() || Driver()->SafetyViolationTriggered()) {
+                if (!sensor_data.has_value()) {
+                    // If we have an error, we still want to publish the error
+                    // codes
+                    static const uint8_t num_joints = Driver()->Profile().joint_ids.size();
+                    sensor_data = SensorData{.pos = std::vector<float>(num_joints),
+                                             .vel = std::vector<float>(num_joints),
+                                             .crt = std::vector<float>(num_joints),
+                                             .err = error_codes_,
+                                             .timestamp = -1};
+                }
+                else {
+                    std::unique_lock<std::mutex> cache_lock{cache_mutex_};
+                    // merge sensor_data's error codes with the existing ones
+                    // with bitwise OR
+                    error_codes_.resize(sensor_data.value().err.size());
+                    for (size_t i = 0; i < sensor_data.value().err.size(); i++) {
+                        // Do not call SetErrorCode() here, due to deadlocking
+                        // of cache_mutex_
+                        error_codes_[i] |= sensor_data.value().err[i];
+                        if (!logged && sensor_data.value().err[i] != 0) {
+                            spdlog::error("Guardian thread detected hardware error for "
+                                          "motor {}. Error "
+                                          "code: {}",
+                                          i, sensor_data.value().err[i]);
+                        }
+                    }
+                    sensor_data_cache_ = SensorData{.pos = sensor_data.value().pos,
+                                                    .vel = sensor_data.value().vel,
+                                                    .crt = sensor_data.value().crt,
+                                                    .err = error_codes_};
+                    sensor_data = sensor_data_cache_;
+                    num_consecutive_read_errors_ = 0;
+                }
+                std::string message = nlohmann::json(sensor_data.value()).dump();
+                std::lock_guard<std::mutex> lock{conns_mutex_};
+                for (const WebSocketConnectionPtr& conn : conns_) {
+                    conn->send(message);
+                }
+
+                // If a safety violation is triggered, Slow down to a stop.
+                // This way, user will have to reset on client-side, but the
+                // server will keep running. NOTE: We need to put this check
+                // before all the triggers below, so that one last message
+                // containing the error codes will be sent to the client before
+                // we stop the arm here.
+                if (Driver()->SafetyViolationTriggered()) {
+                    if (!logged) {
+                        spdlog::error("Guardian thread safety violation checking "
+                                      "ignored. Safety "
+                                      "violation is already triggered.");
+                        SlowDownToStop(sensor_data.value());
+                        logged = true;
+                    }
+                }
+                else {
+                    logged = false;
+                }
+
+                // if hardware error is detected, trigger safety violation mode
+                if (sensor_data.value().err.size() > 0) {
+                    for (const auto& error_code : sensor_data.value().err) {
+                        if (error_code != 0) {
+                            Driver()->TriggerSafetyViolationMode();
+                            break;
+                        }
+                    }
+                }
+
+                // GuardianThread also has the dual role of monitoring for
+                // safety e.g., checking for velocity limit violations
+                std::vector<float> curr_velocities = sensor_data.value().vel;
+                for (int i = 0; i < curr_velocities.size(); i++) {
+                    float cv = fabs(curr_velocities[i]);
+                    float limit = safety_velocity_limits[i];
+                    if (cv > limit) {
+                        Driver()->TriggerSafetyViolationMode();
+                        SetErrorCode(i, kErrorVelocityLimitViolation);
+                        if (!logged)
+                            spdlog::error("Guardian thread detected velocity limit "
+                                          "violation for motor "
+                                          "{}. Current velocity: {}, Limit: {}",
+                                          i, cv, limit);
+                    }
+                }
+
+                // Check for current limit violations
+                std::vector<float> curr_currents = sensor_data.value().crt;
+                for (int i = 0; i < curr_currents.size(); i++) {
+                    float cc = fabs(curr_currents[i]);
+                    float limit = safety_current_limits[i];
+                    if (cc > limit) {
+                        Driver()->TriggerSafetyViolationMode();
+                        // Set error_code_ to 1 for the motor that violated the
+                        // limit
+                        SetErrorCode(i, kErrorCurrentLimitViolation);
+                        if (!logged)
+                            spdlog::error("Guardian thread detected current limit "
+                                          "violation for motor "
+                                          "{}. Current current: {}, Limit: {}",
+                                          i, cc, limit);
+                    }
+                }
             }
-          }
-          sensor_data_cache_ = SensorData{.pos = sensor_data.value().pos,
-                                          .vel = sensor_data.value().vel,
-                                          .crt = sensor_data.value().crt,
-                                          .err = error_codes_};
-          sensor_data = sensor_data_cache_;
-          num_consecutive_read_errors_ = 0;
-        }
-        std::string message = nlohmann::json(sensor_data.value()).dump();
-        std::lock_guard<std::mutex> lock{conns_mutex_};
-        for (const WebSocketConnectionPtr &conn : conns_) {
-          conn->send(message);
-        }
-
-        // If a safety violation is triggered, Slow down to a stop.
-        // This way, user will have to reset on client-side, but the server
-        // will keep running.
-        // NOTE: We need to put this check before all the triggers below,
-        // so that one last message containing the error codes will be sent
-        // to the client before we stop the arm here.
-        if (Driver()->SafetyViolationTriggered()) {
-          if (!logged) {
-            spdlog::error(
-                "Guardian thread safety violation checking ignored. Safety "
-                "violation is already triggered.");
-            SlowDownToStop(sensor_data.value());
-            logged = true;
-          }
-        } else {
-          logged = false;
-        }
-
-        // if hardware error is detected, trigger safety violation mode
-        if (sensor_data.value().err.size() > 0) {
-          for (const auto &error_code : sensor_data.value().err) {
-            if (error_code != 0) {
-              Driver()->TriggerSafetyViolationMode();
-              break;
+            else if (!Driver()->SafetyViolationTriggered()) {
+                // When fail to read, accumulate the counter, check for
+                // threshold and warn, and keep waiting. NOTE: no need to
+                // trigger a power cycle here, given CheckAndSetPosition already
+                // does a motor health check.
+                ++num_consecutive_read_errors_;
+                if (num_consecutive_read_errors_ > MAX_TOLERABLE_CONSECUTIVE_NUM_READ_ERRORS) {
+                    if (!logged)
+                        spdlog::critical("Encounter {} consecutive read errors, which is "
+                                         "considered too "
+                                         "many. Sleeping before retry..",
+                                         num_consecutive_read_errors_);
+                    Driver()->TriggerSafetyViolationMode();
+                    SetErrorCode(0, kErrorMotorNotReachable);
+                    num_consecutive_read_errors_ = 0;
+                    std::this_thread::sleep_for(std::chrono::seconds(3));
+                }
             }
-          }
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
         }
-
-        // GuardianThread also has the dual role of monitoring for safety
-        // e.g., checking for velocity limit violations
-        std::vector<float> curr_velocities = sensor_data.value().vel;
-        for (int i = 0; i < curr_velocities.size(); i++) {
-          float cv = fabs(curr_velocities[i]);
-          float limit = safety_velocity_limits[i];
-          if (cv > limit) {
-            Driver()->TriggerSafetyViolationMode();
-            SetErrorCode(i, kErrorVelocityLimitViolation);
-            if (!logged) spdlog::error(
-                "Guardian thread detected velocity limit violation for motor "
-                "{}. Current velocity: {}, Limit: {}",
-                i,
-                cv,
-                limit);
-          }
-        }
-
-        // Check for current limit violations
-        std::vector<float> curr_currents = sensor_data.value().crt;
-        for (int i = 0; i < curr_currents.size(); i++) {
-          float cc = fabs(curr_currents[i]);
-          float limit = safety_current_limits[i];
-          if (cc > limit) {
-            Driver()->TriggerSafetyViolationMode();
-            // Set error_code_ to 1 for the motor that violated the limit
-            SetErrorCode(i, kErrorCurrentLimitViolation);
-            if (!logged) spdlog::error(
-                "Guardian thread detected current limit violation for motor "
-                "{}. Current current: {}, Limit: {}",
-                i,
-                cc,
-                limit);
-          }
-        }
-      } else if (!Driver()->SafetyViolationTriggered()) {
-        // When fail to read, accumulate the counter, check for threshold and
-        // warn, and keep waiting.
-        // NOTE: no need to trigger a power cycle here, given CheckAndSetPosition
-        // already does a motor health check.
-        ++num_consecutive_read_errors_;
-        if (num_consecutive_read_errors_ >
-            MAX_TOLERABLE_CONSECUTIVE_NUM_READ_ERRORS) {
-          if (!logged) spdlog::critical(
-              "Encounter {} consecutive read errors, which is considered too "
-              "many. Sleeping before retry..",
-              num_consecutive_read_errors_);
-          Driver()->TriggerSafetyViolationMode();
-          SetErrorCode(0, kErrorMotorNotReachable);
-          num_consecutive_read_errors_ = 0;
-          std::this_thread::sleep_for(std::chrono::seconds(3));
-        }
-      }
-      std::this_thread::sleep_for(std::chrono::milliseconds(1));
-    }
-  });
+    });
 }
 
 const SensorData WxArmorWebController::GuardianThread::GetCachedSensorData() {
-  std::unique_lock<std::mutex> cache_lock{cache_mutex_};
-  return sensor_data_cache_;
+    std::unique_lock<std::mutex> cache_lock{cache_mutex_};
+    return sensor_data_cache_;
 }
 
 void WxArmorWebController::GuardianThread::ResetErrorCodes() {
-  std::unique_lock<std::mutex> cache_lock{cache_mutex_};
-  for (uint32_t &error_code : error_codes_) {
-    error_code = 0;
-  }
-  Driver()->ResetSafetyViolationMode();
+    std::unique_lock<std::mutex> cache_lock{cache_mutex_};
+    for (uint32_t& error_code : error_codes_) {
+        error_code = 0;
+    }
+    Driver()->ResetSafetyViolationMode();
 }
 
 void WxArmorWebController::GuardianThread::SetErrorCode(uint8_t motor_id, uint32_t error_code) {
-  std::unique_lock<std::mutex> cache_lock{cache_mutex_};
-  error_codes_[motor_id] |= error_code;
+    std::unique_lock<std::mutex> cache_lock{cache_mutex_};
+    error_codes_[motor_id] |= error_code;
 }
 
 WxArmorWebController::GuardianThread::~GuardianThread() {
-  shutdown_.store(true);
-  if (thread_.joinable()) {
-    thread_.join();
-  }
+    shutdown_.store(true);
+    if (thread_.joinable()) {
+        thread_.join();
+    }
 }
 
-void WxArmorWebController::GuardianThread::Subscribe(
-    const WebSocketConnectionPtr &conn) {
-  // Clear all safety violations only if there are no previous connections
-  if (conns_.empty()) {
-    Driver()->ResetSafetyViolationMode();
-  }
-  std::lock_guard<std::mutex> lock{conns_mutex_};
-  conns_.emplace_back(conn);
+void WxArmorWebController::GuardianThread::Subscribe(const WebSocketConnectionPtr& conn) {
+    // Clear all safety violations only if there are no previous connections
+    if (conns_.empty()) {
+        Driver()->ResetSafetyViolationMode();
+    }
+    std::lock_guard<std::mutex> lock{conns_mutex_};
+    conns_.emplace_back(conn);
 }
 
-void WxArmorWebController::GuardianThread::Unsubscribe(
-    const WebSocketConnectionPtr &conn) {
-  std::lock_guard<std::mutex> lock{conns_mutex_};
-  conns_.erase(std::remove(conns_.begin(), conns_.end(), conn), conns_.end());
+void WxArmorWebController::GuardianThread::Unsubscribe(const WebSocketConnectionPtr& conn) {
+    std::lock_guard<std::mutex> lock{conns_mutex_};
+    conns_.erase(std::remove(conns_.begin(), conns_.end(), conn), conns_.end());
 }
 
 void WxArmorWebController::GuardianThread::KillConnections() {
-  for (auto &conn : conns_) {
-    // TODO(andrew): log which joint was responsible?
-    conn->shutdown(drogon::CloseCode::kViolation,
-                   "Shutting down due to safety violation.");
-  }
-  conns_.clear();
+    for (auto& conn : conns_) {
+        // TODO(andrew): log which joint was responsible?
+        conn->shutdown(drogon::CloseCode::kViolation, "Shutting down due to safety violation.");
+    }
+    conns_.clear();
 }
 
 }  // namespace horizon::wx_armor

--- a/wx_armor/wx_armor/wx_armor_ws.h
+++ b/wx_armor/wx_armor/wx_armor_ws.h
@@ -14,150 +14,153 @@
 #include "drogon/WebSocketController.h"
 #include "wx_armor/wx_armor_driver.h"
 
-namespace horizon::wx_armor {
+namespace horizon::wx_armor
+{
 
-WxArmorDriver *Driver();
+WxArmorDriver* Driver();
 
 // This is for bookkeeping purpose. We maintain ClientState for each of the
 // client that talks to the server.
-struct ClientState {
-  // Upon connection establishment, engaging is `false`. It is switched to
-  // `true` as soon as the first `SETPOS` command is received.
-  bool engaging = false;
+struct ClientState
+{
+    // Upon connection establishment, engaging is `false`. It is switched to
+    // `true` as soon as the first `SETPOS` command is received.
+    bool engaging = false;
 
-  // Record the time of the last SETPOS command. This can be used to check
-  // whether the client stops publishing command for too long.
-  std::chrono::time_point<std::chrono::system_clock> latest_healthy_time{};
+    // Record the time of the last SETPOS command. This can be used to check
+    // whether the client stops publishing command for too long.
+    std::chrono::time_point<std::chrono::system_clock> latest_healthy_time{};
 };
 
-class WxArmorWebController
-    : public drogon::WebSocketController<WxArmorWebController> {
- public:
-  // Callback when a new message is received.
-  virtual void handleNewMessage(const drogon::WebSocketConnectionPtr &,
-                                std::string &&,
-                                const drogon::WebSocketMessageType &) override;
+class WxArmorWebController : public drogon::WebSocketController<WxArmorWebController>
+{
+  public:
+    // Callback when a new message is received.
+    virtual void handleNewMessage(const drogon::WebSocketConnectionPtr&, std::string&&,
+                                  const drogon::WebSocketMessageType&) override;
 
-  // Callback upon closing of a connection.
-  virtual void handleConnectionClosed(
-      const drogon::WebSocketConnectionPtr &) override;
+    // Callback upon closing of a connection.
+    virtual void handleConnectionClosed(const drogon::WebSocketConnectionPtr&) override;
 
-  // Callback upon a new connection is established.
-  virtual void handleNewConnection(
-      const drogon::HttpRequestPtr &,
-      const drogon::WebSocketConnectionPtr &) override;
+    // Callback upon a new connection is established.
+    virtual void handleNewConnection(const drogon::HttpRequestPtr&,
+                                     const drogon::WebSocketConnectionPtr&) override;
 
-  void CheckAndSetPosition(const std::vector<float> &cmd, float moving_time);
+    void CheckAndSetPosition(const std::vector<float>& cmd, float moving_time);
 
-  // Listens on the `"/api/engage"` path for websocket connection.
-  WS_PATH_LIST_BEGIN
-  WS_PATH_ADD("/api/engage", drogon::Get);
-  WS_PATH_LIST_END
+    // Listens on the `"/api/engage"` path for websocket connection.
+    WS_PATH_LIST_BEGIN
+    WS_PATH_ADD("/api/engage", drogon::Get);
+    WS_PATH_LIST_END
 
- private:
-  // The GuardianThread is responsible for 1) continuously (by running a
-  // background thread) read the sensor data and publish it to the clients that
-  // subscribe the sensor data and 2) monitoring for safety violations and
-  // notifying WxArmorDriver accordingly to prevent system damage.
-  //
-  // TODO(hobot):
-  //
-  // Currently the GuardianThread does several things, i.e. the continuous
-  // reading (the thread part), the joint velocity safety check (the guardian
-  // part), and sending the readings to the clients.
-  //
-  // However, there is additional safety checking for action delta in the
-  // WxAarmorWebController.  This is not ideal.
-  //
-  // In the future, the Guardian should be moved to a separate class as a
-  // wrapper for the WxArmorDriver.  It should contain the safety_violation_
-  // related logic in the current WxArmorDriver.
-  //
-  // The WebController should be yet another layer on top of the Guardian class,
-  // to handle sending the readings to the clients (via injecting a callback to
-  // the Guardian's reading thread), and sending actions to the WxArmorDriver.
-  class GuardianThread {
-   public:
-    GuardianThread();
-    ~GuardianThread();
+  private:
+    // The GuardianThread is responsible for 1) continuously (by running a
+    // background thread) read the sensor data and publish it to the clients
+    // that subscribe the sensor data and 2) monitoring for safety violations
+    // and notifying WxArmorDriver accordingly to prevent system damage.
+    //
+    // TODO(hobot):
+    //
+    // Currently the GuardianThread does several things, i.e. the continuous
+    // reading (the thread part), the joint velocity safety check (the guardian
+    // part), and sending the readings to the clients.
+    //
+    // However, there is additional safety checking for action delta in the
+    // WxAarmorWebController.  This is not ideal.
+    //
+    // In the future, the Guardian should be moved to a separate class as a
+    // wrapper for the WxArmorDriver.  It should contain the safety_violation_
+    // related logic in the current WxArmorDriver.
+    //
+    // The WebController should be yet another layer on top of the Guardian
+    // class, to handle sending the readings to the clients (via injecting a
+    // callback to the Guardian's reading thread), and sending actions to the
+    // WxArmorDriver.
+    class GuardianThread
+    {
+      public:
+        GuardianThread();
+        ~GuardianThread();
 
-    // Add the client (identified by the connection) to the subscription list.
-    void Subscribe(const drogon::WebSocketConnectionPtr &conn);
+        // Add the client (identified by the connection) to the subscription
+        // list.
+        void Subscribe(const drogon::WebSocketConnectionPtr& conn);
 
-    // Remove the client (identified by the connection) to the subscription
-    // list.
-    void Unsubscribe(const drogon::WebSocketConnectionPtr &conn);
+        // Remove the client (identified by the connection) to the subscription
+        // list.
+        void Unsubscribe(const drogon::WebSocketConnectionPtr& conn);
 
-    // Close and remove all client connections from subscription list
-    void KillConnections();
+        // Close and remove all client connections from subscription list
+        void KillConnections();
 
-    /**
-     * @brief Returns the sensor data cached from the latest read.
-     *
-     * @return A copy of the sensor data.
-     */
-    const SensorData GetCachedSensorData();
+        /**
+         * @brief Returns the sensor data cached from the latest read.
+         *
+         * @return A copy of the sensor data.
+         */
+        const SensorData GetCachedSensorData();
 
-    const static uint32_t kErrorCommandDeltaTooLarge = 1 << 9;
-    const static uint32_t kErrorVelocityLimitViolation = 1 << 10;
-    const static uint32_t kErrorCurrentLimitViolation = 1 << 11;
-    const static uint32_t kErrorMotorNotReachable = 1 << 12;
+        const static uint32_t kErrorCommandDeltaTooLarge = 1 << 9;
+        const static uint32_t kErrorVelocityLimitViolation = 1 << 10;
+        const static uint32_t kErrorCurrentLimitViolation = 1 << 11;
+        const static uint32_t kErrorMotorNotReachable = 1 << 12;
 
-    /**
-     * @brief Resets the error codes for all motors.
-     */
-    void ResetErrorCodes();
+        /**
+         * @brief Resets the error codes for all motors.
+         */
+        void ResetErrorCodes();
 
-    /**
-     * @brief Sets the error code for a specific motor.
-     */
-    void SetErrorCode(uint8_t motor_id, uint32_t error_code);
+        /**
+         * @brief Sets the error code for a specific motor.
+         */
+        void SetErrorCode(uint8_t motor_id, uint32_t error_code);
 
-   private:
-    std::mutex conns_mutex_;  // protects conns_
-    std::vector<drogon::WebSocketConnectionPtr> conns_{};
+      private:
+        std::mutex conns_mutex_;  // protects conns_
+        std::vector<drogon::WebSocketConnectionPtr> conns_{};
 
-    std::atomic_bool shutdown_{false};
-    std::jthread thread_{};
+        std::atomic_bool shutdown_{false};
+        std::jthread thread_{};
 
-    // Book keeping of the number of read errors in a row. Reset to 0 as soon as
-    // a successful read is seen. Server will crash as soon as this number
-    // exceeds the threshold.
-    int num_consecutive_read_errors_ = 0;
+        // Book keeping of the number of read errors in a row. Reset to 0 as
+        // soon as a successful read is seen. Server will crash as soon as this
+        // number exceeds the threshold.
+        int num_consecutive_read_errors_ = 0;
 
-    SensorData sensor_data_cache_;
-    std::mutex
-        cache_mutex_;  // protects read/write access to sensor_data_cache.
+        SensorData sensor_data_cache_;
+        std::mutex cache_mutex_;  // protects read/write access to sensor_data_cache.
 
-    // Error codes for all motors, protected by cache_mutex_.
-    // lower 8 bits are for dynamixel errors,
-    // bit 9 is for command delta too large,
-    // bit 10 is joint velocity limit violation,
-    // bit 11 is joint over current limit violation,
-    std::vector<uint32_t> error_codes_{};
-  };
+        // Error codes for all motors, protected by cache_mutex_.
+        // lower 8 bits are for dynamixel errors,
+        // bit 9 is for command delta too large,
+        // bit 10 is joint velocity limit violation,
+        // bit 11 is joint over current limit violation,
+        std::vector<uint32_t> error_codes_{};
+    };
 
-  GuardianThread guardian_thread_;
+    GuardianThread guardian_thread_;
 };
 
 // Helper function to read the environment variable.
 template <typename T>
-T GetEnv(const char *name, T default_value) {
-  const char *text = std::getenv(name);
+T GetEnv(const char* name, T default_value) {
+    const char* text = std::getenv(name);
 
-  if (text == nullptr) {
-    return default_value;
-  }
+    if (text == nullptr) {
+        return default_value;
+    }
 
-  if constexpr (std::is_same_v<T, std::string>) {
-    return std::string(text);
-  } else if constexpr (std::is_integral_v<T>) {
-    return static_cast<T>(std::stoi(text));
-  } else if constexpr (std::is_same_v<T, std::filesystem::path>) {
-    return std::filesystem::path(text);
-  }
+    if constexpr (std::is_same_v<T, std::string>) {
+        return std::string(text);
+    }
+    else if constexpr (std::is_integral_v<T>) {
+        return static_cast<T>(std::stoi(text));
+    }
+    else if constexpr (std::is_same_v<T, std::filesystem::path>) {
+        return std::filesystem::path(text);
+    }
 
-  std::abort();
+    std::abort();
 }
 
 }  // namespace horizon::wx_armor


### PR DESCRIPTION
Add a `.pre-commit-config.yaml` file with basic hooks and enforcing the `clang-format`. I also updated the `clang-format` with some of my personal settings that I find really helps code clarity. These are the same as the one used in `kincpp`. The biggest difference is using an indent width of 4. I personally find an indent width of 2 very hard to read code.

Should review PR #26 before this one.