### PR TITLE
Add MotorHealthThread

### DIFF
--- a/wx_armor/CMakeLists.txt
+++ b/wx_armor/CMakeLists.txt
@@ -70,6 +70,19 @@ target_link_libraries(guardian_thread PUBLIC
         nlohmann_json::nlohmann_json
 )
 
+add_library(motor_health_thread STATIC)
+target_sources(motor_health_thread
+        PUBLIC
+        FILE_SET HEADERS
+        BASE_DIRS wx_armor
+        FILES wx_armor/motor_health_thread.h
+        PRIVATE wx_armor/motor_health_thread.cc)
+target_link_libraries(motor_health_thread PUBLIC
+        wx_armor_driver
+        spdlog::spdlog
+        guardian_thread
+)
+
 add_library(wx_armor_ws STATIC)
 target_sources(wx_armor_ws
     PUBLIC
@@ -81,6 +94,7 @@ target_link_libraries(wx_armor_ws PUBLIC
     Drogon::Drogon
     spdlog::spdlog
     guardian_thread
+    motor_health_thread
     wx_armor_driver)
 
 add_executable(wx_armor)
@@ -102,7 +116,7 @@ install(FILES
     DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME})
 
 install(
-    TARGETS robot_profile wx_armor_driver wx_armor_ws wx_armor guardian_thread
+    TARGETS robot_profile wx_armor_driver wx_armor_ws wx_armor guardian_thread motor_health_thread
     EXPORT ${PROJECT_NAME}_Targets
     FILE_SET HEADERS)
 

--- a/wx_armor/wx_armor/motor_health_thread.cc
+++ b/wx_armor/wx_armor/motor_health_thread.cc
@@ -1,0 +1,40 @@
+#include "wx_armor/motor_health_thread.h"
+#include "wx_armor/guardian_thread.h"
+#include "wx_armor/wx_armor_driver.h"
+
+#include "spdlog/spdlog.h"
+
+namespace horizon::wx_armor
+{
+
+MotorHealthThread::MotorHealthThread(const std::shared_ptr<GuardianThread>& guardian)
+    : thread_ready_(false), stop_thread_(false), guardian_thread_(guardian) {
+    worker_thread_ = std::thread(&MotorHealthThread::CheckMotorHealth, this);
+
+    // Block until the thread is ready.
+    while (!thread_ready_) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    }
+}
+
+MotorHealthThread::~MotorHealthThread() {
+    stop_thread_.store(true);
+    if (worker_thread_.joinable()) {
+        worker_thread_.join();
+        spdlog::info("MotorHealthThread has joined.");
+    }
+}
+
+void MotorHealthThread::CheckMotorHealth() {
+    while (!stop_thread_) {
+        if (!Driver()->SafetyViolationTriggered() && !Driver()->MotorHealthCheck()) {
+            const SensorData readings = guardian_thread_->GetCachedSensorData();
+            Driver()->TriggerSafetyViolationMode();
+            guardian_thread_->SetErrorCode(0, GuardianThread::kErrorMotorNotReachable);
+            SlowDownToStop(readings);
+        }
+        thread_ready_.store(true);
+    }
+}
+
+}  // namespace horizon::wx_armor

--- a/wx_armor/wx_armor/motor_health_thread.h
+++ b/wx_armor/wx_armor/motor_health_thread.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <atomic>
+#include <memory>
+#include <thread>
+
+namespace horizon::wx_armor
+{
+
+class GuardianThread;
+
+/**
+ * This is a thread for continuously checking the health of the dynamixel motors via pinging.
+ * If the motors cannot be pinged, it will communicate this to the GuardianThread accordingly.
+ */
+class MotorHealthThread
+{
+  public:
+    explicit MotorHealthThread(const std::shared_ptr<GuardianThread>& guardian_thread);
+    ~MotorHealthThread();
+
+  private:
+    /**
+     * @brief The worker function that continuously checks the health of the motors.
+     */
+    void CheckMotorHealth();
+
+    // The GuardianThread that we forward errors to.
+    std::shared_ptr<GuardianThread> guardian_thread_;
+
+    // The worker thread.
+    std::thread worker_thread_;
+
+    // Thread-safe flags for setting ready and stop states.
+    std::atomic<bool> thread_ready_;
+    std::atomic<bool> stop_thread_;
+};
+
+}  // namespace horizon::wx_armor


### PR DESCRIPTION
This PR adds a new thread `MotorHealthThread` that will perform the motor health pinging operations. This will eliminate the latency bug caused by pinging when executing a `MOVETO` command in the main thread. If the motors cannot be pinged, the `MotorHealthThread` will communicate this accordingly to the `GuardianThread` as well as execute a slow down command.

Please review PR #28 before this one.