### PR TITLE
Fix latency bug by reading errors with syncRead

### DIFF
--- a/wx_armor/wx_armor/guardian_thread.cc
+++ b/wx_armor/wx_armor/guardian_thread.cc
@@ -24,7 +24,7 @@ GuardianThread::GuardianThread() {
                     // If we have an error, we still want to publish the error
                     // codes
                     static const uint8_t num_joints = Driver()->Profile().joint_ids.size();
-                    static const uint8_t num_motors = Driver()->Profile().joint_ids.size();
+                    static const uint8_t num_motors = Driver()->Profile().motor_ids.size();
                     sensor_data = SensorData{.pos = std::vector<float>(num_joints),
                                              .vel = std::vector<float>(num_joints),
                                              .crt = std::vector<float>(num_motors),

--- a/wx_armor/wx_armor/guardian_thread.cc
+++ b/wx_armor/wx_armor/guardian_thread.cc
@@ -169,7 +169,7 @@ void GuardianThread::SetErrorCode(uint8_t motor_idx, int32_t error_code, bool is
         if (motor_idx > 1) {
             idx++;
         }
-        if (motor_idx > 3) {
+        if (motor_idx > 2) {
             idx++;
         }
     }

--- a/wx_armor/wx_armor/guardian_thread.h
+++ b/wx_armor/wx_armor/guardian_thread.h
@@ -55,10 +55,10 @@ class GuardianThread
      */
     const SensorData GetCachedSensorData();
 
-    const static uint32_t kErrorCommandDeltaTooLarge = 1 << 9;
-    const static uint32_t kErrorVelocityLimitViolation = 1 << 10;
-    const static uint32_t kErrorCurrentLimitViolation = 1 << 11;
-    const static uint32_t kErrorMotorNotReachable = 1 << 12;
+    const static int32_t kErrorCommandDeltaTooLarge = 1 << 9;
+    const static int32_t kErrorVelocityLimitViolation = 1 << 10;
+    const static int32_t kErrorCurrentLimitViolation = 1 << 11;
+    const static int32_t kErrorMotorNotReachable = 1 << 12;
 
     /**
      * @brief Resets the error codes for all motors.
@@ -67,8 +67,14 @@ class GuardianThread
 
     /**
      * @brief Sets the error code for a specific motor.
+     *
+     * Args:
+     *     motor_idx: The motor index to set the error code for. Note that this is
+     *         an index and NOT the motor ID, which usually starts from 1.
+     *     error_code: The error code to set for the motor.
+     *     is_joint_idx: If True, will consider the motor_idx, a joint_idx and map accordingly.
      */
-    void SetErrorCode(uint8_t motor_id, uint32_t error_code);
+    void SetErrorCode(uint8_t motor_idx, int32_t error_code, bool is_joint_idx = false);
 
   private:
     std::mutex conns_mutex_;  // protects conns_
@@ -90,7 +96,7 @@ class GuardianThread
     // bit 9 is for command delta too large,
     // bit 10 is joint velocity limit violation,
     // bit 11 is joint over current limit violation,
-    std::vector<uint32_t> error_codes_{};
+    std::vector<int32_t> error_codes_{};
 };
 
 }  // namespace horizon::wx_armor

--- a/wx_armor/wx_armor/robot_profile.cc
+++ b/wx_armor/wx_armor/robot_profile.cc
@@ -13,6 +13,7 @@ bool convert<horizon::wx_armor::RobotProfile>::decode(const Node& node,
     for (const auto& child : node["motors"]) {
         YAML::Node info = child.second;
         uint8_t motor_id = info["ID"].as<uint8_t>();
+        profile.motor_ids.push_back(motor_id);
 
         // Safety velocity limit is given in [deg/s]. Convert it to [rad/s]
         float safety_vel_limit = info["Safety_Velocity_Limit"].as<float>();

--- a/wx_armor/wx_armor/robot_profile.h
+++ b/wx_armor/wx_armor/robot_profile.h
@@ -107,6 +107,7 @@ struct RegistryKV
 struct RobotProfile
 {
     std::vector<MotorInfo> motors{};
+    std::vector<uint8_t> motor_ids{};
     std::vector<uint8_t> joint_ids{};
     std::vector<std::string> joint_names{};
     std::vector<RegistryKV> eeprom{};

--- a/wx_armor/wx_armor/wx_armor_driver.cc
+++ b/wx_armor/wx_armor/wx_armor_driver.cc
@@ -413,13 +413,12 @@ std::optional<SensorData> WxArmorDriver::Read() {
 std::vector<float> WxArmorDriver::GetSafetyVelocityLimits() {
     std::vector<float> safety_velocity_limits;
 
-    int counter = 0;
     for (const auto& motor : profile_.motors) {
         // Skip the shadowed motors, which have IDs 3 and 5.
-        if (counter != 2 && counter != 4) {
-            safety_velocity_limits.push_back(motor.safety_vel_limit);
+        if (motor.id == 3 || motor.id == 5) {
+            continue;
         }
-        counter++;
+        safety_velocity_limits.push_back(motor.safety_vel_limit);
     }
     return safety_velocity_limits;
 }

--- a/wx_armor/wx_armor/wx_armor_driver.h
+++ b/wx_armor/wx_armor/wx_armor_driver.h
@@ -65,10 +65,10 @@ struct SensorData
     // │ Per Joint        │
     // └──────────────────┘
 
-    std::vector<float> pos{};     // joint position
-    std::vector<float> vel{};     // joint velocity
-    std::vector<float> crt{};     // motor electric current of this joint
-    std::vector<uint32_t> err{};  // per joint error codes
+    std::vector<float> pos{};    // joint position
+    std::vector<float> vel{};    // joint velocity
+    std::vector<float> crt{};    // motor electric current of this joint
+    std::vector<int32_t> err{};  // per joint error codes
 
     // ┌──────────────────┐
     // │ Metadata         │
@@ -156,13 +156,6 @@ class WxArmorDriver
      * if the read fails.
      */
     std::optional<SensorData> Read();
-
-    /**
-     * @brief Check that all motors are health.
-     *
-     * @return Returns true if all motors are reachable and false otherwise.
-     */
-    bool MotorHealthCheck();
 
     /**
      * @brief Reads the safety velocity limits from RobotProfile and returns it.


### PR DESCRIPTION
This PR removes the high latency during move to commands caused by pinging the motors.

It now reads errors during the `syncRead` call which produces virtually 0 overhead.
In addition to this, we also now have currents be reported at motor level instead of joint level.