### PR TITLE
Add software-based reboot functionality

### DIFF
--- a/wx_armor/wx_armor/wx_armor_driver.h
+++ b/wx_armor/wx_armor/wx_armor_driver.h
@@ -268,6 +268,11 @@ class WxArmorDriver
         return profile_;
     }
 
+    /**
+     * @brief Reboot any motors in an error state.
+     */
+    void RebootMotors();
+
   private:
     ControlItem AddItemToRead(const std::string& name);
 

--- a/wx_armor/wx_armor/wx_armor_ws.cc
+++ b/wx_armor/wx_armor/wx_armor_ws.cc
@@ -72,6 +72,12 @@ void WxArmorWebController::handleNewMessage(const WebSocketConnectionPtr& conn,
         CheckAndSetPosition(position, moving_time);
     }
     else if (set_pid) {
+        // Make sure to set the position to the current one in case
+        // we are resetting PID after a hard reset to avoid large jumps.
+        std::optional<SensorData> sensor_data = Driver()->Read();
+        if (sensor_data.has_value()) {
+            CheckAndSetPosition(sensor_data.value().pos, 0.0);
+        }
         std::vector<PIDGain> gain_cfgs = nlohmann::json::parse(payload);
         Driver()->SetPID(gain_cfgs);
         guardian_thread_.ResetErrorCodes();


### PR DESCRIPTION
This PR adds software-based reboot functionality.

On the Hobot side, if we send a websocket message containing "REBOOT", the driver will send a REBOOT packet to faulted motors, essentially power cycling them.

This will allow us to circumvent the physical wifi power socket.

I also ordered the websocket message handling if else so that we don't call `Match` redundantly.

Please review PR #31 before this one.

Note that an accompanying Hobot-side PR will be submitted once this is ready for review.