### PR TITLE
increase velocity limits and delta action limits for human in the loop teleoperation

### DIFF
--- a/wx_armor/configs/wx250s_motor_config.yaml
+++ b/wx_armor/configs/wx250s_motor_config.yaml
@@ -28,7 +28,7 @@
 #                                    Note that the effect of this value changes depending on the control mode and motor type.
 #                                    Only XM-series motors officially have this register, so we will avoid writing it to the
 #                                    XL-series ones. In position control mode, this value is unused. In current-based position
-#                                    control mode, this value is used as the maximum current allowed. Since the Gagentoal_Current
+#                                    control mode, this value is used as the maximum current allowed. Since the Goal_Current
 #                                    value is always less than or equal to this value, this value is generally unused as well.
 #                                    What we do use this value for is to initiate a software-based error if the current of a
 #                                    motor ever exceeds this value. Again, note that this should only ever happen under position

--- a/wx_armor/configs/wx250s_motor_config.yaml
+++ b/wx_armor/configs/wx250s_motor_config.yaml
@@ -17,7 +17,7 @@
 #                                    appropriate register value
 #   5) Velocity_Limit................Defines the max speed of the motor. A value of '131' corresponds to a max speed
 #                                    of PI rad/s. NOTE: this is only used in velocity control mode. I.e., has no effect
-#                                    in the default position control setting.
+#                                    in the default position control setting, except for kErrorVelocityLimitViolation enforced.
 #   6) Goal_Current..................Defines the goal current [0-Current_Limit] of the motor. Any value > 0 will cause
 #                                    the motor to operate in current-based position control mode with the specified goal current.
 #                                    This value must be less than or equal to Current_Limit. Look below for the conversion.
@@ -28,7 +28,7 @@
 #                                    Note that the effect of this value changes depending on the control mode and motor type.
 #                                    Only XM-series motors officially have this register, so we will avoid writing it to the
 #                                    XL-series ones. In position control mode, this value is unused. In current-based position
-#                                    control mode, this value is used as the maximum current allowed. Since the Goal_Current
+#                                    control mode, this value is used as the maximum current allowed. Since the Gagentoal_Current
 #                                    value is always less than or equal to this value, this value is generally unused as well.
 #                                    What we do use this value for is to initiate a software-based error if the current of a
 #                                    motor ever exceeds this value. Again, note that this should only ever happen under position
@@ -91,7 +91,7 @@ motors:
     Baud_Rate: 3
     Return_Delay_Time: 0
     Drive_Mode: 4
-    Velocity_Limit: 131
+    Velocity_Limit: 262
     Goal_Current: *goal_current_value
     Current_Limit: 1193
     Min_Position_Limit: 0
@@ -106,7 +106,7 @@ motors:
     Baud_Rate: 3
     Return_Delay_Time: 0
     Drive_Mode: 4
-    Velocity_Limit: 131
+    Velocity_Limit: 262
     Goal_Current: *goal_current_value
     Current_Limit: 1193
     Min_Position_Limit: 819
@@ -121,7 +121,7 @@ motors:
     Baud_Rate: 3
     Return_Delay_Time: 0
     Drive_Mode: 5
-    Velocity_Limit: 131
+    Velocity_Limit: 262
     Goal_Current: *goal_current_value
     Current_Limit: 1193
     Min_Position_Limit: 819
@@ -135,7 +135,7 @@ motors:
     Baud_Rate: 3
     Return_Delay_Time: 0
     Drive_Mode: 4
-    Velocity_Limit: 131
+    Velocity_Limit: 262
     Goal_Current: *goal_current_value
     Current_Limit: 1193
     Min_Position_Limit: 648
@@ -150,7 +150,7 @@ motors:
     Baud_Rate: 3
     Return_Delay_Time: 0
     Drive_Mode: 5
-    Velocity_Limit: 131
+    Velocity_Limit: 262
     Goal_Current: *goal_current_value
     Current_Limit: 1193
     Min_Position_Limit: 648
@@ -164,7 +164,7 @@ motors:
     Baud_Rate: 3
     Return_Delay_Time: 0
     Drive_Mode: 4
-    Velocity_Limit: 131
+    Velocity_Limit: 262
     Goal_Current: *goal_current_value
     Current_Limit: 1193
     Min_Position_Limit: 0
@@ -179,7 +179,7 @@ motors:
     Baud_Rate: 3
     Return_Delay_Time: 0
     Drive_Mode: 5
-    Velocity_Limit: 131
+    Velocity_Limit: 262
     Goal_Current: *goal_current_value
     Current_Limit: 1193
     Min_Position_Limit: 910
@@ -195,7 +195,7 @@ motors:
     Baud_Rate: 3
     Return_Delay_Time: 0
     Drive_Mode: 4
-    Velocity_Limit: 131
+    Velocity_Limit: 262
     Current_Limit: 800
     Min_Position_Limit: 0
     Max_Position_Limit: 4095
@@ -209,8 +209,8 @@ motors:
     Baud_Rate: 3
     Return_Delay_Time: 0
     Drive_Mode: 4
-    Velocity_Limit: 131
-    Current_Limit: 800
+    Velocity_Limit: 262
+    Current_Limit: 1300
     Min_Position_Limit: 0
     Max_Position_Limit: 4095
     Secondary_ID: 255

--- a/wx_armor/wx_armor/wx_armor_ws.cc
+++ b/wx_armor/wx_armor/wx_armor_ws.cc
@@ -129,6 +129,7 @@ void WxArmorWebController::CheckAndSetPosition(const std::vector<float>& cmd, fl
         float thd = 0.2;
         if (moving_time > 0.1)
             thd = 2.5 * moving_time;
+            thd *= 2; // due to pd control overshooting and safer teleop.
         if (fabs(reading - cmd[i]) > thd && !Driver()->SafetyViolationTriggered()) {
             spdlog::error("Joint {} command is out of range: {} -> {} > {}. Command "
                           "ignored.",


### PR DESCRIPTION
as title

These limits are probably not very safe if pure RL, but since we are using teleop and HIL, they are Ok.
Note, when wrist rotate and elbow rotate are aligned, singularity occurs, and joint vel can be large also.  Try to avoid singularity as possible.